### PR TITLE
Refactor editor lifecycle and stabilize document flows

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,78 +1,23 @@
-/**
- * App – root component.
- *
- * Creates the Tiptap editor instance and owns the open / save handlers.
- * Passes the editor down to Toolbar (for formatting commands) and
- * EditorArea (for rendering), keeping both components thin.
- */
-import { useCallback, useEffect } from "react";
-import { useEditor } from "@tiptap/react";
-import StarterKit from "@tiptap/starter-kit";
-
 import Layout from "../components/Layout";
 import Toolbar from "../components/Toolbar";
 import EditorArea from "../features/editor/Editor";
 import StatusBar from "../components/StatusBar";
 
-import { openDocument, saveDocument } from "../features/documents/documentService";
 import { useDocumentStore } from "../stores/documentStore";
-
-/** Sample content shown when no file is open. */
-const WELCOME_HTML = `
-<h1>Welcome to mdedit</h1>
-<p>A lightweight WYSIWYG Markdown editor. Click <strong>Open</strong> in the toolbar to load a <code>.md</code> file, or start typing here.</p>
-<h2>Supported formatting</h2>
-<ul>
-  <li><strong>Bold</strong> and <em>italic</em> text</li>
-  <li>Headings, bullet &amp; ordered lists</li>
-  <li>Blockquotes and code blocks</li>
-  <li>Inline <code>code</code> and horizontal rules</li>
-</ul>
-<blockquote><p>Edit in rich text — save as Markdown.</p></blockquote>
-<pre><code>const hello = "world";</code></pre>
-<hr>
-<p>Use the toolbar above or standard keyboard shortcuts (Ctrl+B, Ctrl+I, …) to format text.</p>
-`;
+import { useEditorController } from "../features/editor/useEditorController";
 
 export default function App() {
-  const { isDirty, currentFilePath, markDirty } = useDocumentStore();
-
-  const editor = useEditor({
-    extensions: [StarterKit],
-    content: WELCOME_HTML,
-    onUpdate: () => {
-      markDirty();
-    },
-  });
-
-  const handleOpen = useCallback(async () => {
-    const html = await openDocument();
-    if (html !== null && editor) {
-      // Replace editor content without triggering the onUpdate dirty flag
-      editor.commands.setContent(html, false);
-    }
-  }, [editor]);
-
-  const handleSave = useCallback(async () => {
-    if (!editor) return;
-    await saveDocument(editor.getHTML());
-  }, [editor]);
-
-  // Ctrl+S / Cmd+S keyboard shortcut for save
-  useEffect(() => {
-    const onKeyDown = (e: KeyboardEvent) => {
-      if ((e.ctrlKey || e.metaKey) && e.key === "s") {
-        e.preventDefault();
-        handleSave();
-      }
-    };
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [handleSave]);
+  const { isDirty, currentFilePath } = useDocumentStore();
+  const { editor, handleOpen, handleSave, handleSaveAs } = useEditorController();
 
   return (
     <Layout>
-      <Toolbar editor={editor} onOpen={handleOpen} onSave={handleSave} />
+      <Toolbar
+        editor={editor}
+        onOpen={() => void handleOpen()}
+        onSave={() => void handleSave()}
+        onSaveAs={() => void handleSaveAs()}
+      />
       <EditorArea editor={editor} />
       <StatusBar isDirty={isDirty} filePath={currentFilePath} />
     </Layout>

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,8 +1,5 @@
 /**
  * StatusBar component.
- *
- * Shows the currently open file path and a dirty indicator when the
- * document has unsaved changes.
  */
 import { basename } from "../lib/utils";
 
@@ -12,18 +9,17 @@ interface StatusBarProps {
 }
 
 export default function StatusBar({ isDirty, filePath }: StatusBarProps) {
-  const label = filePath ? basename(filePath) : "No file open";
+  const filename = filePath ? basename(filePath) : "Untitled";
+  const dirtyLabel = isDirty ? "Modified" : "Saved";
 
   return (
     <div className="status-bar" role="status" aria-live="polite">
       <span className="status-path" title={filePath ?? undefined}>
-        {label}
+        {filename}
       </span>
-      {isDirty && (
-        <span className="status-dirty" title="Unsaved changes">
-          ● Unsaved
-        </span>
-      )}
+      <span className={`status-dirty ${isDirty ? "is-modified" : "is-saved"}`}>
+        {dirtyLabel}
+      </span>
     </div>
   );
 }

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,8 +1,5 @@
 /**
  * Toolbar component.
- *
- * Shows file actions (Open / Save) and inline formatting controls that
- * operate directly on the Tiptap editor instance.
  */
 import type { Editor } from "@tiptap/react";
 
@@ -10,12 +7,12 @@ interface ToolbarProps {
   editor: Editor | null;
   onOpen: () => void;
   onSave: () => void;
+  onSaveAs: () => void;
 }
 
-export default function Toolbar({ editor, onOpen, onSave }: ToolbarProps) {
+export default function Toolbar({ editor, onOpen, onSave, onSaveAs }: ToolbarProps) {
   return (
     <div className="toolbar" role="toolbar" aria-label="Editor toolbar">
-      {/* File actions */}
       <div className="toolbar-group">
         <button onClick={onOpen} title="Open Markdown file">
           Open
@@ -23,11 +20,13 @@ export default function Toolbar({ editor, onOpen, onSave }: ToolbarProps) {
         <button onClick={onSave} title="Save file (Ctrl+S)">
           Save
         </button>
+        <button onClick={onSaveAs} title="Save as...">
+          Save As
+        </button>
       </div>
 
       <div className="toolbar-divider" aria-hidden />
 
-      {/* Formatting actions – disabled when editor is not ready */}
       <div className="toolbar-group">
         <button
           onClick={() => editor?.chain().focus().toggleBold().run()}

--- a/src/features/documents/documentService.ts
+++ b/src/features/documents/documentService.ts
@@ -1,72 +1,79 @@
 /**
  * Document service.
  *
- * Orchestrates the open/save workflow by combining the Tauri bridge (native
- * I/O), the markdown service (format conversion), and the document store
- * (application state).  React components should call these functions instead
- * of importing the bridge or store directly.
+ * Orchestrates open/save workflow by combining the Tauri bridge (native I/O),
+ * markdown conversion and the document store.
  */
 import { useDocumentStore } from "../../stores/documentStore";
 import * as bridge from "../../services/tauriBridge";
 import { markdownToHtml, htmlToMarkdown } from "../../services/markdownService";
+import type { OpenDocumentResult, SaveDocumentResult } from "../../types";
+
+export type ConfirmDiscardChanges = () => Promise<boolean>;
+
+interface OpenDocumentOptions {
+  confirmDiscardChanges?: ConfirmDiscardChanges;
+}
 
 /**
- * Opens the native file-picker dialog, reads the chosen Markdown file, and
- * returns the HTML string to load into the editor.  Updates the store with
- * the new file path and raw content.
- *
- * Returns `null` if the dialog was cancelled or the file could not be read.
+ * Open flow with dirty-check confirmation.
  */
-export async function openDocument(): Promise<string | null> {
-  const { setContent, setFilePath, resetDirty } =
-    useDocumentStore.getState();
+export async function openDocument(
+  options: OpenDocumentOptions = {}
+): Promise<OpenDocumentResult> {
+  const { isDirty, markLoaded } = useDocumentStore.getState();
+
+  if (isDirty && options.confirmDiscardChanges) {
+    const canDiscard = await options.confirmDiscardChanges();
+    if (!canDiscard) {
+      return { kind: "cancelled" };
+    }
+  }
 
   const filePath = await bridge.openFileDialog();
-  if (!filePath) return null;
+  if (!filePath) {
+    return { kind: "cancelled" };
+  }
 
   const markdown = await bridge.readTextFile(filePath);
   const html = await markdownToHtml(markdown);
 
-  setContent(markdown);
-  setFilePath(filePath);
-  resetDirty();
+  markLoaded({ markdown, path: filePath });
 
-  return html;
+  return { kind: "opened", html };
 }
 
 /**
- * Saves the current editor HTML to the currently open file path as Markdown.
- * Falls back to `saveDocumentAs` when no path is known yet.
+ * Save flow. If no file path exists, falls back to Save As.
  */
-export async function saveDocument(editorHtml: string): Promise<void> {
-  const { currentFilePath, setContent, resetDirty } =
-    useDocumentStore.getState();
+export async function saveDocument(editorHtml: string): Promise<SaveDocumentResult> {
+  const { currentFilePath, markSaved } = useDocumentStore.getState();
 
   if (!currentFilePath) {
-    await saveDocumentAs(editorHtml);
-    return;
+    return saveDocumentAs(editorHtml);
   }
 
   const markdown = await htmlToMarkdown(editorHtml);
   await bridge.saveTextFile(currentFilePath, markdown);
-  setContent(markdown);
-  resetDirty();
+  markSaved({ markdown, path: currentFilePath });
+
+  return { kind: "saved", path: currentFilePath };
 }
 
 /**
- * Shows the native save-file dialog, converts the editor HTML to Markdown,
- * and writes it to the chosen path.  Updates the store on success.
+ * Save As flow. Always opens native save dialog.
  */
-export async function saveDocumentAs(editorHtml: string): Promise<void> {
-  const { setContent, setFilePath, resetDirty } =
-    useDocumentStore.getState();
-
+export async function saveDocumentAs(
+  editorHtml: string
+): Promise<SaveDocumentResult> {
+  const { markSaved } = useDocumentStore.getState();
   const markdown = await htmlToMarkdown(editorHtml);
-  const savedPath = await bridge.saveFileDialog(markdown);
 
-  if (savedPath) {
-    setContent(markdown);
-    setFilePath(savedPath);
-    resetDirty();
+  const savedPath = await bridge.saveFileDialog(markdown);
+  if (!savedPath) {
+    return { kind: "cancelled" };
   }
+
+  markSaved({ markdown, path: savedPath });
+  return { kind: "saved", path: savedPath };
 }

--- a/src/features/editor/useEditorController.ts
+++ b/src/features/editor/useEditorController.ts
@@ -1,0 +1,151 @@
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useEditor, type Editor } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+
+import { basename } from "../../lib/utils";
+import {
+  openDocument,
+  saveDocument,
+  saveDocumentAs,
+} from "../documents/documentService";
+import * as bridge from "../../services/tauriBridge";
+import { useDocumentStore } from "../../stores/documentStore";
+
+const APP_NAME = "mdedit";
+
+const WELCOME_HTML = `
+<h1>Welcome to mdedit</h1>
+<p>A lightweight WYSIWYG Markdown editor. Click <strong>Open</strong> in the toolbar to load a <code>.md</code> file, or start typing here.</p>
+<h2>Supported formatting</h2>
+<ul>
+  <li><strong>Bold</strong> and <em>italic</em> text</li>
+  <li>Headings, bullet &amp; ordered lists</li>
+  <li>Blockquotes and code blocks</li>
+  <li>Inline <code>code</code> and horizontal rules</li>
+</ul>
+<blockquote><p>Edit in rich text — save as Markdown.</p></blockquote>
+<pre><code>const hello = "world";</code></pre>
+<hr>
+<p>Use the toolbar above or standard keyboard shortcuts (Ctrl+B, Ctrl+I, …) to format text.</p>
+`;
+
+function buildWindowTitle(path: string | null, isDirty: boolean): string {
+  if (!path) return APP_NAME;
+  const prefix = isDirty ? "*" : "";
+  return `${prefix}${basename(path)} - ${APP_NAME}`;
+}
+
+function confirmDiscardUnsavedChanges(): Promise<boolean> {
+  return Promise.resolve(
+    window.confirm("You have unsaved changes. Discard them?")
+  );
+}
+
+export interface EditorController {
+  editor: Editor | null;
+  handleOpen: () => Promise<void>;
+  handleSave: () => Promise<void>;
+  handleSaveAs: () => Promise<void>;
+}
+
+export function useEditorController(): EditorController {
+  const isApplyingRemoteContent = useRef(false);
+  const allowCloseRef = useRef(false);
+  const { isDirty, currentFilePath, setDirty } = useDocumentStore();
+
+  const editor = useEditor({
+    extensions: [StarterKit],
+    content: WELCOME_HTML,
+    onUpdate: ({ editor: nextEditor }) => {
+      if (isApplyingRemoteContent.current) return;
+      const html = nextEditor.getHTML();
+      if (html.length > 0) {
+        setDirty(true);
+      }
+    },
+  });
+
+  const handleOpen = useCallback(async () => {
+    const result = await openDocument({
+      confirmDiscardChanges: confirmDiscardUnsavedChanges,
+    });
+
+    if (result.kind !== "opened" || !result.html || !editor) {
+      return;
+    }
+
+    isApplyingRemoteContent.current = true;
+    editor.commands.setContent(result.html, false);
+    isApplyingRemoteContent.current = false;
+  }, [editor]);
+
+  const handleSave = useCallback(async () => {
+    if (!editor) return;
+    await saveDocument(editor.getHTML());
+  }, [editor]);
+
+  const handleSaveAs = useCallback(async () => {
+    if (!editor) return;
+    await saveDocumentAs(editor.getHTML());
+  }, [editor]);
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "s") {
+        e.preventDefault();
+        void handleSave();
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [handleSave]);
+
+  useEffect(() => {
+    const title = buildWindowTitle(currentFilePath, isDirty);
+    void bridge.setWindowTitle(title);
+  }, [currentFilePath, isDirty]);
+
+  useEffect(() => {
+    const onBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (!useDocumentStore.getState().isDirty) return;
+      event.preventDefault();
+      event.returnValue = "";
+    };
+
+    window.addEventListener("beforeunload", onBeforeUnload);
+    return () => window.removeEventListener("beforeunload", onBeforeUnload);
+  }, []);
+
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+
+    void bridge.onWindowCloseRequested(async (event) => {
+      if (allowCloseRef.current) {
+        return;
+      }
+
+      if (!useDocumentStore.getState().isDirty) {
+        return;
+      }
+
+      event.preventDefault();
+      const canDiscard = await confirmDiscardUnsavedChanges();
+      if (!canDiscard) return;
+
+      allowCloseRef.current = true;
+      await bridge.closeCurrentWindow();
+    }).then((cleanup) => {
+      unlisten = cleanup;
+    });
+
+    return () => {
+      if (unlisten) unlisten();
+    };
+  }, []);
+
+  return useMemo(
+    () => ({ editor, handleOpen, handleSave, handleSaveAs }),
+    [editor, handleOpen, handleSave, handleSaveAs]
+  );
+}

--- a/src/services/tauriBridge.ts
+++ b/src/services/tauriBridge.ts
@@ -1,33 +1,45 @@
 /**
  * Tauri bridge service.
  *
- * Thin wrapper around Tauri's `invoke` that types all custom Rust commands.
- * Import from here instead of calling `invoke` directly in components or
- * business logic layers.
+ * Thin wrapper around Tauri APIs, typed and centralized.
  */
 import { invoke } from "@tauri-apps/api/core";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import type { UnlistenFn } from "@tauri-apps/api/event";
 
-/** Shows the OS file-open dialog filtered to Markdown files.
- *  Returns the selected absolute path, or null if the dialog was cancelled. */
+/** Shows the OS file-open dialog filtered to Markdown files. */
 export async function openFileDialog(): Promise<string | null> {
   return invoke<string | null>("open_file_dialog");
 }
 
-/** Reads the UTF-8 text content of the file at `path`. */
+/** Reads UTF-8 text file content by absolute path. */
 export async function readTextFile(path: string): Promise<string> {
   return invoke<string>("read_text_file", { path });
 }
 
-/** Writes `content` to the file at `path`, creating it if necessary. */
-export async function saveTextFile(
-  path: string,
-  content: string
-): Promise<void> {
+/** Writes `content` to the file at `path`. */
+export async function saveTextFile(path: string, content: string): Promise<void> {
   return invoke<void>("save_text_file", { path, content });
 }
 
-/** Shows the OS save dialog, writes `content` to the chosen path.
- *  Returns the saved absolute path, or null if the dialog was cancelled. */
+/** Shows save dialog, writes `content`, and returns saved path. */
 export async function saveFileDialog(content: string): Promise<string | null> {
   return invoke<string | null>("save_file_dialog", { content });
+}
+
+/** Updates native window title. */
+export async function setWindowTitle(title: string): Promise<void> {
+  await getCurrentWindow().setTitle(title);
+}
+
+/** Registers a Tauri close-request handler (supports preventDefault). */
+export async function onWindowCloseRequested(
+  listener: (event: { preventDefault: () => void }) => void | Promise<void>
+): Promise<UnlistenFn> {
+  return getCurrentWindow().onCloseRequested(listener);
+}
+
+/** Closes current window (used after explicit discard confirmation). */
+export async function closeCurrentWindow(): Promise<void> {
+  await getCurrentWindow().close();
 }

--- a/src/stores/documentStore.ts
+++ b/src/stores/documentStore.ts
@@ -1,18 +1,67 @@
 import { create } from "zustand";
-import type { DocumentStore } from "../types";
+import type { ActiveDocument, DocumentStore } from "../types";
+import { basename } from "../lib/utils";
+
+const EMPTY_DOCUMENT: ActiveDocument = {
+  path: null,
+  name: null,
+  lastLoadedContent: "",
+  lastSavedContent: "",
+  lastSavedAt: null,
+  fileMtime: null,
+  lastKnownPath: null,
+};
 
 /**
  * Global document state.
- * Tracks which file is open, its raw markdown content, and whether it is dirty.
+ * Tracks active file metadata, markdown content, and unsaved state.
  */
 export const useDocumentStore = create<DocumentStore>((set) => ({
-  activeDocument: null,
+  activeDocument: EMPTY_DOCUMENT,
   documentContent: "",
   isDirty: false,
   currentFilePath: null,
 
   setContent: (content) => set({ documentContent: content }),
-  markDirty: () => set({ isDirty: true }),
-  setFilePath: (path) => set({ currentFilePath: path, activeDocument: path }),
+  setFilePath: (path) =>
+    set((state) => ({
+      currentFilePath: path,
+      activeDocument: {
+        ...state.activeDocument,
+        path,
+        name: path ? basename(path) : null,
+        lastKnownPath: path,
+      },
+    })),
+  markLoaded: ({ markdown, path }) =>
+    set(() => ({
+      documentContent: markdown,
+      currentFilePath: path,
+      isDirty: false,
+      activeDocument: {
+        path,
+        name: path ? basename(path) : null,
+        lastLoadedContent: markdown,
+        lastSavedContent: markdown,
+        lastSavedAt: new Date().toISOString(),
+        fileMtime: null,
+        lastKnownPath: path,
+      },
+    })),
+  markSaved: ({ markdown, path }) =>
+    set((state) => ({
+      documentContent: markdown,
+      currentFilePath: path,
+      isDirty: false,
+      activeDocument: {
+        ...state.activeDocument,
+        path,
+        name: path ? basename(path) : null,
+        lastSavedContent: markdown,
+        lastSavedAt: new Date().toISOString(),
+        lastKnownPath: path,
+      },
+    })),
+  setDirty: (dirty) => set({ isDirty: dirty }),
   resetDirty: () => set({ isDirty: false }),
 }));

--- a/src/styles.css
+++ b/src/styles.css
@@ -254,7 +254,14 @@ body {
 }
 
 .status-dirty {
-  color: var(--color-dirty);
   flex-shrink: 0;
   margin-left: 12px;
+}
+
+.status-dirty.is-modified {
+  color: var(--color-dirty);
+}
+
+.status-dirty.is-saved {
+  color: var(--color-text-muted);
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,10 +1,28 @@
 /** Application-level TypeScript types. */
 
+/** Metadata carried with the currently active document. */
+export interface ActiveDocument {
+  /** Absolute path on disk; null for untitled documents. */
+  path: string | null;
+  /** Basename derived from path, or null for untitled documents. */
+  name: string | null;
+  /** Last markdown loaded from disk/open flow. */
+  lastLoadedContent: string;
+  /** Last markdown that was successfully written to disk. */
+  lastSavedContent: string;
+  /** Timestamp when save/open last synchronized persisted content. */
+  lastSavedAt: string | null;
+  /** Reserved for future external file change detection. */
+  fileMtime: number | null;
+  /** Path snapshot for future file move/rename resolution. */
+  lastKnownPath: string | null;
+}
+
 /** State shape managed by the document Zustand store. */
 export interface DocumentState {
-  /** Display name / path of the active document (null if none open). */
-  activeDocument: string | null;
-  /** Raw markdown text of the current document as persisted on disk. */
+  /** Active document model; null before initialization. */
+  activeDocument: ActiveDocument;
+  /** Raw markdown text currently represented by editor content. */
   documentContent: string;
   /** True when the editor has unsaved changes. */
   isDirty: boolean;
@@ -16,12 +34,26 @@ export interface DocumentState {
 export interface DocumentActions {
   /** Replace stored markdown content (does not mark dirty). */
   setContent: (content: string) => void;
+  /** Update active file path details. */
+  setFilePath: (path: string | null) => void;
+  /** Update metadata after load/open sync. */
+  markLoaded: (payload: { markdown: string; path: string | null }) => void;
+  /** Update metadata after successful save. */
+  markSaved: (payload: { markdown: string; path: string | null }) => void;
   /** Mark the document as having unsaved changes. */
-  markDirty: () => void;
-  /** Set the file path and update the active document name. */
-  setFilePath: (path: string) => void;
+  setDirty: (dirty: boolean) => void;
   /** Clear the dirty flag (call after a successful save). */
   resetDirty: () => void;
+}
+
+export interface OpenDocumentResult {
+  kind: "opened" | "cancelled";
+  html?: string;
+}
+
+export interface SaveDocumentResult {
+  kind: "saved" | "cancelled";
+  path?: string | null;
 }
 
 export type DocumentStore = DocumentState & DocumentActions;


### PR DESCRIPTION
### Motivation

- Separate editor orchestration from `App.tsx` so the root component is a thin shell and editor/document lifecycle is centralized for clearer control and testability.
- Improve `dirty` state handling and the open/save/save-as flows so user changes are detected only from real editor updates and saves reliably reset dirty state.
- Provide safe native confirm-on-close/reload/open behavior using Tauri APIs and prepare the store/types for future external file-change detection.

### Description

- Extracted orchestration into a new hook `useEditorController` which creates the Tiptap editor, sets `dirty` only on real user updates, prevents update loops when applying remote content, wires `Ctrl/Cmd+S`, updates window title and handles confirm-on-close and `beforeunload` behavior (`src/features/editor/useEditorController.ts`).
- Centralized open/save/save-as logic in `documentService` with typed return objects (`OpenDocumentResult` / `SaveDocumentResult`) and a configurable discard-confirm step for `openDocument`; `saveDocument` falls back to `saveDocumentAs` when no `currentFilePath` exists (`src/features/documents/documentService.ts`).
- Expanded the document model and store to carry `ActiveDocument` metadata (`lastLoadedContent`, `lastSavedContent`, `lastSavedAt`, `lastKnownPath`, `fileMtime` placeholder) and added `markLoaded` / `markSaved` / `setDirty` actions to maintain lifecycle and reset dirty state after successful sync (`src/types/index.ts`, `src/stores/documentStore.ts`).
- Added Tauri window helpers to the bridge for title updates and close-request handling (`setWindowTitle`, `onWindowCloseRequested`, `closeCurrentWindow`) and kept file I/O bridge functions typed and centralized (`src/services/tauriBridge.ts`).
- Slimmed `App.tsx` to a thin shell that composes layout and plugs in handlers from `useEditorController` (`src/app/App.tsx`).
- UI tweaks: added `Save As` to the toolbar, improved `StatusBar` to show filename or `Untitled` and `Modified`/`Saved` state with tooltip for full path, and small CSS adjustments for status variants (`src/components/Toolbar.tsx`, `src/components/StatusBar.tsx`, `src/styles.css`).
- Confirm/close handling details: the Tauri close flow uses `getCurrentWindow().onCloseRequested(listener)` to receive the close request, calls `event.preventDefault()` when the document is dirty to stop the immediate close, shows a discard confirmation, then calls `getCurrentWindow().close()` after user confirms; `beforeunload` is also used to cover webview reload scenarios (`src/services/tauriBridge.ts`, `src/features/editor/useEditorController.ts`).

### Testing

- Ran the production build via `npm run build` (which runs `tsc` + `vite build`); the build completed successfully.
- No automated unit tests were added in this iteration and no additional test runners were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5535cfbcc832290a489d583d7d2b1)