### PR TITLE
Add explicit reload-from-disk workflow for external file changes

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -8,15 +8,19 @@ import { useEditorController } from "../features/editor/useEditorController";
 
 export default function App() {
   const { isDirty, currentFilePath, activeDocument } = useDocumentStore();
-  const { editor, handleOpen, handleSave, handleSaveAs } = useEditorController();
+  const { editor, handleOpen, handleReload, handleSave, handleSaveAs } =
+    useEditorController();
 
   return (
     <Layout>
       <Toolbar
         editor={editor}
         onOpen={() => void handleOpen()}
+        onReload={() => void handleReload()}
         onSave={() => void handleSave()}
         onSaveAs={() => void handleSaveAs()}
+        canReload={Boolean(currentFilePath)}
+        highlightReload={activeDocument.hasExternalChangeWarning}
       />
       <EditorArea editor={editor} />
       <StatusBar

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -14,16 +14,39 @@ import {
 interface ToolbarProps {
   editor: Editor | null;
   onOpen: () => void;
+  onReload: () => void;
   onSave: () => void;
   onSaveAs: () => void;
+  canReload: boolean;
+  highlightReload: boolean;
 }
 
-export default function Toolbar({ editor, onOpen, onSave, onSaveAs }: ToolbarProps) {
+export default function Toolbar({
+  editor,
+  onOpen,
+  onReload,
+  onSave,
+  onSaveAs,
+  canReload,
+  highlightReload,
+}: ToolbarProps) {
   return (
     <div className="toolbar" role="toolbar" aria-label="Editor toolbar">
       <div className="toolbar-group">
         <button onClick={onOpen} title="Open Markdown file">
           Open
+        </button>
+        <button
+          onClick={onReload}
+          disabled={!canReload}
+          className={highlightReload ? "recommended" : ""}
+          title={
+            canReload
+              ? "Reload current file from disk"
+              : "Reload is available only for saved files"
+          }
+        >
+          Reload
         </button>
         <button onClick={onSave} title="Save file (Ctrl+S)">
           Save

--- a/src/features/documents/documentService.ts
+++ b/src/features/documents/documentService.ts
@@ -10,7 +10,11 @@ import {
   parseMarkdownToEditorContent,
   serializeEditorToMarkdown,
 } from "../../services/markdownService";
-import type { OpenDocumentResult, SaveDocumentResult } from "../../types";
+import type {
+  OpenDocumentResult,
+  ReloadDocumentResult,
+  SaveDocumentResult,
+} from "../../types";
 
 export type ConfirmDiscardChanges = () => Promise<boolean>;
 
@@ -48,6 +52,7 @@ export async function openDocument(
     canonicalMarkdown,
     path: filePath,
     fileMtime: metadata.modifiedMs,
+    source: "open",
   });
 
   return { kind: "opened", html: editorContent };
@@ -91,6 +96,48 @@ export async function saveDocumentAs(): Promise<SaveDocumentResult> {
     fileMtime: metadata.modifiedMs,
   });
   return { kind: "saved", path: savedPath };
+}
+
+/** Explicit reload flow for the currently open document path. */
+export async function reloadDocumentFromDisk(
+  options: OpenDocumentOptions = {}
+): Promise<ReloadDocumentResult> {
+  const { currentFilePath, isDirty, markLoaded } = useDocumentStore.getState();
+
+  if (!currentFilePath) {
+    return { kind: "noop" };
+  }
+
+  if (isDirty && options.confirmDiscardChanges) {
+    const canDiscard = await options.confirmDiscardChanges();
+    if (!canDiscard) {
+      return { kind: "cancelled" };
+    }
+  }
+
+  try {
+    const rawMarkdown = await bridge.readTextFile(currentFilePath);
+    const { editorContent, canonicalMarkdown } =
+      await parseMarkdownToEditorContent(rawMarkdown);
+    const metadata = await bridge.getFileMetadata(currentFilePath);
+
+    markLoaded({
+      rawMarkdown,
+      canonicalMarkdown,
+      path: currentFilePath,
+      fileMtime: metadata.modifiedMs,
+      source: "reload",
+    });
+
+    return { kind: "reloaded", html: editorContent };
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : "Failed to reload document from disk.";
+
+    return { kind: "error", message };
+  }
 }
 
 /**

--- a/src/features/editor/useEditorController.ts
+++ b/src/features/editor/useEditorController.ts
@@ -17,6 +17,7 @@ import { basename } from "../../lib/utils";
 import {
   openDocument,
   reconcileCanonicalFromEditorHtml,
+  reloadDocumentFromDisk,
   saveDocument,
   saveDocumentAs,
 } from "../documents/documentService";
@@ -56,6 +57,7 @@ function confirmDiscardUnsavedChanges(): Promise<boolean> {
 export interface EditorController {
   editor: Editor | null;
   handleOpen: () => Promise<void>;
+  handleReload: () => Promise<void>;
   handleSave: () => Promise<void>;
   handleSaveAs: () => Promise<void>;
 }
@@ -128,6 +130,25 @@ export function useEditorController(): EditorController {
     await saveDocument();
   }, [editor, syncCurrentEditorCanonical]);
 
+  const handleReload = useCallback(async () => {
+    const result = await reloadDocumentFromDisk({
+      confirmDiscardChanges: confirmDiscardUnsavedChanges,
+    });
+
+    if (result.kind === "error") {
+      window.alert(`Reload failed: ${result.message ?? "Unknown error"}`);
+      return;
+    }
+
+    if (result.kind !== "reloaded" || !result.html || !editor) {
+      return;
+    }
+
+    isApplyingRemoteContent.current = true;
+    editor.commands.setContent(result.html, false);
+    isApplyingRemoteContent.current = false;
+  }, [editor]);
+
   const handleSaveAs = useCallback(async () => {
     if (!editor) return;
     await syncCurrentEditorCanonical();
@@ -197,8 +218,11 @@ export function useEditorController(): EditorController {
     const checkExternalChange = async () => {
       if (isRunning) return;
 
-      const { currentFilePath: activePath, activeDocument, markExternalChangeWarning } =
-        useDocumentStore.getState();
+      const {
+        currentFilePath: activePath,
+        activeDocument,
+        markExternalChangeWarning,
+      } = useDocumentStore.getState();
 
       if (!activePath || activeDocument.fileMtime === null) {
         return;
@@ -211,7 +235,10 @@ export function useEditorController(): EditorController {
           metadata.modifiedMs !== null &&
           metadata.modifiedMs !== activeDocument.fileMtime
         ) {
-          markExternalChangeWarning(new Date().toISOString());
+          markExternalChangeWarning({
+            detectedAt: new Date().toISOString(),
+            detectedMtime: metadata.modifiedMs,
+          });
         }
       } finally {
         isRunning = false;
@@ -238,7 +265,7 @@ export function useEditorController(): EditorController {
   }, []);
 
   return useMemo(
-    () => ({ editor, handleOpen, handleSave, handleSaveAs }),
-    [editor, handleOpen, handleSave, handleSaveAs]
+    () => ({ editor, handleOpen, handleReload, handleSave, handleSaveAs }),
+    [editor, handleOpen, handleReload, handleSave, handleSaveAs]
   );
 }

--- a/src/stores/documentStore.ts
+++ b/src/stores/documentStore.ts
@@ -12,6 +12,9 @@ const EMPTY_DOCUMENT: ActiveDocument = {
   lastKnownPath: null,
   hasExternalChangeWarning: false,
   externalChangeDetectedAt: null,
+  lastReloadedAt: null,
+  lastObservedDiskMtime: null,
+  isDiskVersionInSyncWithBaseline: true,
 };
 
 /**
@@ -34,7 +37,7 @@ export const useDocumentStore = create<DocumentStore>((set) => ({
         lastKnownPath: path,
       },
     })),
-  markLoaded: ({ rawMarkdown, canonicalMarkdown, path, fileMtime }) =>
+  markLoaded: ({ rawMarkdown, canonicalMarkdown, path, fileMtime, source }) =>
     set(() => ({
       currentCanonicalMarkdown: canonicalMarkdown,
       currentFilePath: path,
@@ -49,6 +52,10 @@ export const useDocumentStore = create<DocumentStore>((set) => ({
         lastKnownPath: path,
         hasExternalChangeWarning: false,
         externalChangeDetectedAt: null,
+        lastReloadedAt:
+          source === "reload" ? new Date().toISOString() : null,
+        lastObservedDiskMtime: fileMtime,
+        isDiskVersionInSyncWithBaseline: true,
       },
     })),
   markSaved: ({ canonicalMarkdown, path, fileMtime }) =>
@@ -66,6 +73,8 @@ export const useDocumentStore = create<DocumentStore>((set) => ({
         lastKnownPath: path,
         hasExternalChangeWarning: false,
         externalChangeDetectedAt: null,
+        lastObservedDiskMtime: fileMtime,
+        isDiskVersionInSyncWithBaseline: true,
       },
     })),
   reconcileCurrentCanonicalMarkdown: (markdown) =>
@@ -85,26 +94,24 @@ export const useDocumentStore = create<DocumentStore>((set) => ({
         isDirty: shouldBeDirty,
       };
     }),
-  markExternalChangeWarning: (detectedAt) =>
-    set((state) => {
-      if (state.activeDocument.hasExternalChangeWarning) {
-        return state;
-      }
-
-      return {
-        activeDocument: {
-          ...state.activeDocument,
-          hasExternalChangeWarning: true,
-          externalChangeDetectedAt: detectedAt,
-        },
-      };
-    }),
+  markExternalChangeWarning: ({ detectedAt, detectedMtime }) =>
+    set((state) => ({
+      activeDocument: {
+        ...state.activeDocument,
+        hasExternalChangeWarning: true,
+        externalChangeDetectedAt:
+          state.activeDocument.externalChangeDetectedAt ?? detectedAt,
+        lastObservedDiskMtime: detectedMtime,
+        isDiskVersionInSyncWithBaseline: false,
+      },
+    })),
   clearExternalChangeWarning: () =>
     set((state) => ({
       activeDocument: {
         ...state.activeDocument,
         hasExternalChangeWarning: false,
         externalChangeDetectedAt: null,
+        isDiskVersionInSyncWithBaseline: true,
       },
     })),
 }));

--- a/src/styles.css
+++ b/src/styles.css
@@ -110,6 +110,11 @@ body {
   color: var(--color-accent);
 }
 
+.toolbar button.recommended {
+  border-color: #f2c078;
+  background: #fff7ea;
+}
+
 .toolbar button:disabled {
   opacity: 0.4;
   cursor: default;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -26,6 +26,12 @@ export interface ActiveDocument {
   hasExternalChangeWarning: boolean;
   /** ISO timestamp when external change warning was first raised. */
   externalChangeDetectedAt: string | null;
+  /** ISO timestamp when the document was explicitly reloaded from disk. */
+  lastReloadedAt: string | null;
+  /** Last observed mtime from disk checks (used for warning/debug context). */
+  lastObservedDiskMtime: number | null;
+  /** True when current saved baseline is aligned with last known disk version. */
+  isDiskVersionInSyncWithBaseline: boolean;
 }
 
 /** State shape managed by the document Zustand store. */
@@ -50,6 +56,7 @@ export interface DocumentActions {
     canonicalMarkdown: string;
     path: string | null;
     fileMtime: number | null;
+    source: "open" | "reload";
   }) => void;
   /** Update metadata after successful save. */
   markSaved: (payload: {
@@ -60,7 +67,10 @@ export interface DocumentActions {
   /** Reconcile current canonical markdown and derived dirty state. */
   reconcileCurrentCanonicalMarkdown: (markdown: string) => void;
   /** Mark that metadata check observed an external file modification. */
-  markExternalChangeWarning: (detectedAt: string) => void;
+  markExternalChangeWarning: (payload: {
+    detectedAt: string;
+    detectedMtime: number | null;
+  }) => void;
   /** Clear external change warning (e.g. after open/save). */
   clearExternalChangeWarning: () => void;
 }
@@ -76,3 +86,9 @@ export interface SaveDocumentResult {
 }
 
 export type DocumentStore = DocumentState & DocumentActions;
+
+export interface ReloadDocumentResult {
+  kind: "reloaded" | "cancelled" | "noop" | "error";
+  html?: string;
+  message?: string;
+}


### PR DESCRIPTION
### Motivation

- External-change detection was only a passive warning; users need a safe, explicit way to reload the current file from disk without breaking the canonical markdown lifecycle.  
- The reload flow must respect dirty state, be centralized in the `documentService`, and avoid producing spurious dirty events in the editor.

### Description

- Added a typed reload workflow `reloadDocumentFromDisk(...)` to `src/features/documents/documentService.ts` that reads the current `currentFilePath` from the store, respects a discard confirmation when the document is dirty, and uses `markLoaded(..., source: 'reload')` to atomically update store metadata and baseline values.  
- Extended the document state model in `src/types/index.ts` and `src/stores/documentStore.ts` with `lastReloadedAt`, `lastObservedDiskMtime`, `isDiskVersionInSyncWithBaseline`, and updated `markLoaded`/`markSaved`/`markExternalChangeWarning`/`clearExternalChangeWarning` to maintain a clearer external-change lifecycle.  
- Integrated reload into controller and UI: added `handleReload` in `src/features/editor/useEditorController.ts` which calls `reloadDocumentFromDisk` (shows a pragmatic `confirm` for dirty discard and `alert` on error) and safely applies reloaded content under the `isApplyingRemoteContent` guard so no false `onUpdate` reconciliation runs.  
- Exposed a new `Reload` button in `src/components/Toolbar.tsx` and wired it in `src/app/App.tsx` with props `canReload` (disabled when no `currentFilePath`) and `highlightReload` (subtle visual affordance when `hasExternalChangeWarning`); added `recommended` style in `src/styles.css` for the highlight.  
- Files changed: `src/features/documents/documentService.ts` (reload flow), `src/features/editor/useEditorController.ts` (handler & safe setContent), `src/stores/documentStore.ts` (state extensions & warning handling), `src/types/index.ts` (new types), `src/components/Toolbar.tsx` and `src/app/App.tsx` (UI wiring), `src/styles.css` (highlight styles).  

### Testing

- Built the app with `npm run build` and the build completed successfully.  
- Verified repository changes were staged/committed (`git status`/commit produced).  
- No additional automated tests exist for this feature in the repo; manual confirm/dialog and alert behavior are implemented with the existing pragmatic `confirm`/`alert` flows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d573ed0c24832296e51f354d7da908)