### PR TITLE
Add lightweight toast notifications and centralized confirm dialog

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -5,8 +5,9 @@ import StatusBar from "../components/StatusBar";
 
 import { useDocumentStore } from "../stores/documentStore";
 import { useEditorController } from "../features/editor/useEditorController";
+import { AppUxProvider } from "../features/ux/useAppUx";
 
-export default function App() {
+function AppContent() {
   const { isDirty, currentFilePath, activeDocument } = useDocumentStore();
   const {
     editor,
@@ -38,5 +39,13 @@ export default function App() {
         hasExternalChangeWarning={activeDocument.hasExternalChangeWarning}
       />
     </Layout>
+  );
+}
+
+export default function App() {
+  return (
+    <AppUxProvider>
+      <AppContent />
+    </AppUxProvider>
   );
 }

--- a/src/features/documents/fileActionService.ts
+++ b/src/features/documents/fileActionService.ts
@@ -12,12 +12,21 @@ import {
   saveDocumentAs,
   type ConfirmDiscardChanges,
 } from "./documentService";
+import type { ConfirmOptions, ToastOptions } from "../ux/useAppUx";
+
+interface NotificationApi {
+  info: (options: ToastOptions) => void;
+  success: (options: ToastOptions) => void;
+  warning: (options: ToastOptions) => void;
+  error: (options: ToastOptions) => void;
+}
 
 export interface FileActionContext {
   getEditorHtml: () => string | null;
   setEditorHtml: (html: string) => void;
   reconcileCanonicalFromEditorHtml: (html: string) => Promise<string>;
   confirmDiscardChanges: ConfirmDiscardChanges;
+  notify: NotificationApi;
   onStateChanged: (state: PersistedAppState) => void;
 }
 
@@ -28,19 +37,26 @@ export function getInitialPersistedState(): PersistedAppState {
 export async function runOpenAction(
   context: FileActionContext
 ): Promise<void> {
-  const result = await openDocument({
-    confirmDiscardChanges: context.confirmDiscardChanges,
-  });
+  try {
+    const result = await openDocument({
+      confirmDiscardChanges: context.confirmDiscardChanges,
+    });
 
-  if (result.kind !== "opened" || !result.html) {
-    return;
-  }
+    if (result.kind !== "opened" || !result.html) {
+      return;
+    }
 
-  context.setEditorHtml(result.html);
+    context.setEditorHtml(result.html);
 
-  if (result.path) {
-    const state = pushRecentFile(result.path);
-    context.onStateChanged(state);
+    if (result.path) {
+      const state = pushRecentFile(result.path);
+      context.onStateChanged(state);
+    }
+  } catch (error) {
+    context.notify.error({
+      title: "Open failed",
+      message: error instanceof Error ? error.message : "Unknown error.",
+    });
   }
 }
 
@@ -53,7 +69,10 @@ export async function runOpenRecentAction(
   });
 
   if (result.kind === "error") {
-    window.alert(`Open failed: ${result.message ?? "Unknown error"}`);
+    context.notify.error({
+      title: "Open recent failed",
+      message: result.message ?? "Unknown error.",
+    });
     const state = removeRecentFile(path);
     context.onStateChanged(state);
     return;
@@ -72,12 +91,20 @@ export async function runSaveAction(context: FileActionContext): Promise<void> {
   const editorHtml = context.getEditorHtml();
   if (!editorHtml) return;
 
-  await context.reconcileCanonicalFromEditorHtml(editorHtml);
-  const result = await saveDocument();
+  try {
+    await context.reconcileCanonicalFromEditorHtml(editorHtml);
+    const result = await saveDocument();
 
-  if (result.kind === "saved" && result.path) {
-    const state = pushRecentFile(result.path);
-    context.onStateChanged(state);
+    if (result.kind === "saved" && result.path) {
+      const state = pushRecentFile(result.path);
+      context.onStateChanged(state);
+      context.notify.success({ title: "Saved" });
+    }
+  } catch (error) {
+    context.notify.error({
+      title: "Save failed",
+      message: error instanceof Error ? error.message : "Unknown error.",
+    });
   }
 }
 
@@ -87,12 +114,20 @@ export async function runSaveAsAction(
   const editorHtml = context.getEditorHtml();
   if (!editorHtml) return;
 
-  await context.reconcileCanonicalFromEditorHtml(editorHtml);
-  const result = await saveDocumentAs();
+  try {
+    await context.reconcileCanonicalFromEditorHtml(editorHtml);
+    const result = await saveDocumentAs();
 
-  if (result.kind === "saved" && result.path) {
-    const state = pushRecentFile(result.path);
-    context.onStateChanged(state);
+    if (result.kind === "saved" && result.path) {
+      const state = pushRecentFile(result.path);
+      context.onStateChanged(state);
+      context.notify.success({ title: "Saved as", message: result.path });
+    }
+  } catch (error) {
+    context.notify.error({
+      title: "Save As failed",
+      message: error instanceof Error ? error.message : "Unknown error.",
+    });
   }
 }
 
@@ -104,7 +139,10 @@ export async function runReloadAction(
   });
 
   if (result.kind === "error") {
-    window.alert(`Reload failed: ${result.message ?? "Unknown error"}`);
+    context.notify.error({
+      title: "Reload failed",
+      message: result.message ?? "Unknown error.",
+    });
     return;
   }
 
@@ -113,6 +151,7 @@ export async function runReloadAction(
   }
 
   context.setEditorHtml(result.html);
+  context.notify.info({ title: "Reloaded from disk" });
 }
 
 export async function runStartupReopenAction(
@@ -135,5 +174,21 @@ export async function runStartupReopenAction(
   if (result.kind === "error") {
     const nextState = removeRecentFile(state.lastOpenedFilePath);
     context.onStateChanged(nextState);
+    context.notify.warning({
+      title: "Could not reopen last file",
+      message: result.message ?? "File is no longer available.",
+      timeoutMs: 3200,
+    });
   }
+}
+
+export function createDiscardChangesConfirmOptions(): ConfirmOptions {
+  return {
+    title: "Discard unsaved changes?",
+    message: "Your unsaved edits will be lost.",
+    confirmLabel: "Discard",
+    cancelLabel: "Keep Editing",
+    variant: "danger",
+    confirmOnEnter: false,
+  };
 }

--- a/src/features/editor/useEditorController.ts
+++ b/src/features/editor/useEditorController.ts
@@ -16,6 +16,7 @@ import {
 
 import { basename } from "../../lib/utils";
 import * as bridge from "../../services/tauriBridge";
+import { useAppUx } from "../ux/useAppUx";
 import { useDocumentStore } from "../../stores/documentStore";
 import {
   getInitialPersistedState,
@@ -25,6 +26,7 @@ import {
   runSaveAction,
   runSaveAsAction,
   runStartupReopenAction,
+  createDiscardChangesConfirmOptions,
 } from "../documents/fileActionService";
 import { reconcileCanonicalFromEditorHtml } from "../documents/documentService";
 
@@ -42,11 +44,6 @@ function buildWindowTitle(path: string | null, isDirty: boolean): string {
   return `${prefix}${basename(path)} - ${APP_NAME}`;
 }
 
-function confirmDiscardUnsavedChanges(): Promise<boolean> {
-  return Promise.resolve(
-    window.confirm("You have unsaved changes. Discard them?")
-  );
-}
 
 export interface EditorController {
   editor: Editor | null;
@@ -61,10 +58,12 @@ export interface EditorController {
 export function useEditorController(): EditorController {
   const isApplyingRemoteContent = useRef(false);
   const allowCloseRef = useRef(false);
+  const closeConfirmInFlightRef = useRef(false);
   const reconcileRunIdRef = useRef(0);
   const startupReopenDoneRef = useRef(false);
   const [persistedState, setPersistedState] = useState(getInitialPersistedState);
   const { isDirty, currentFilePath } = useDocumentStore();
+  const { confirm, notify } = useAppUx();
 
   const editor = useEditor({
     extensions: [
@@ -101,15 +100,20 @@ export function useEditorController(): EditorController {
     [editor]
   );
 
+  const confirmDiscardUnsavedChanges = useCallback(async () => {
+    return confirm(createDiscardChangesConfirmOptions());
+  }, [confirm]);
+
   const actionContext = useMemo(
     () => ({
       getEditorHtml: () => editor?.getHTML() ?? null,
       setEditorHtml,
       reconcileCanonicalFromEditorHtml,
-      confirmDiscardChanges: confirmDiscardUnsavedChanges,
+      confirmDiscardChanges: () => confirmDiscardUnsavedChanges(),
+      notify,
       onStateChanged: setPersistedState,
     }),
-    [editor, setEditorHtml]
+    [confirmDiscardUnsavedChanges, editor, notify, setEditorHtml]
   );
 
   const handleOpen = useCallback(async () => {
@@ -283,11 +287,25 @@ export function useEditorController(): EditorController {
         }
 
         event.preventDefault();
+        if (closeConfirmInFlightRef.current) {
+          return;
+        }
+
+        closeConfirmInFlightRef.current = true;
         const canDiscard = await confirmDiscardUnsavedChanges();
+        closeConfirmInFlightRef.current = false;
         if (!canDiscard) return;
 
         allowCloseRef.current = true;
-        await bridge.closeCurrentWindow();
+        try {
+          await bridge.closeCurrentWindow();
+        } catch (error) {
+          allowCloseRef.current = false;
+          notify.error({
+            title: "Could not close window",
+            message: error instanceof Error ? error.message : "Unknown error.",
+          });
+        }
       })
       .then((cleanup) => {
         unlisten = cleanup;
@@ -296,7 +314,7 @@ export function useEditorController(): EditorController {
     return () => {
       if (unlisten) unlisten();
     };
-  }, []);
+  }, [confirmDiscardUnsavedChanges, notify]);
 
   useEffect(() => {
     let isRunning = false;

--- a/src/features/ux/useAppUx.tsx
+++ b/src/features/ux/useAppUx.tsx
@@ -1,0 +1,235 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+
+export type ToastKind = "info" | "success" | "warning" | "error";
+
+export interface ToastOptions {
+  title: string;
+  message?: string;
+  timeoutMs?: number;
+}
+
+export interface ConfirmOptions {
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant?: "default" | "danger";
+  confirmOnEnter?: boolean;
+}
+
+interface ToastItem extends ToastOptions {
+  id: number;
+  kind: ToastKind;
+}
+
+interface ActiveConfirm extends ConfirmOptions {
+  resolve: (value: boolean) => void;
+}
+
+interface AppUxContextValue {
+  notify: {
+    info: (options: ToastOptions) => void;
+    success: (options: ToastOptions) => void;
+    warning: (options: ToastOptions) => void;
+    error: (options: ToastOptions) => void;
+  };
+  confirm: (options: ConfirmOptions) => Promise<boolean>;
+}
+
+const AppUxContext = createContext<AppUxContextValue | null>(null);
+
+const DEFAULT_TOAST_TIMEOUT_MS = 3800;
+const ERROR_TOAST_TIMEOUT_MS = 6500;
+
+function createNotificationApi(addToast: (kind: ToastKind, options: ToastOptions) => void) {
+  return {
+    info: (options: ToastOptions) => addToast("info", options),
+    success: (options: ToastOptions) => addToast("success", options),
+    warning: (options: ToastOptions) => addToast("warning", options),
+    error: (options: ToastOptions) => addToast("error", options),
+  };
+}
+
+export function AppUxProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+  const [activeConfirm, setActiveConfirm] = useState<ActiveConfirm | null>(null);
+  const toastIdRef = useRef(0);
+  const confirmQueueRef = useRef<ActiveConfirm[]>([]);
+
+  const dismissToast = useCallback((id: number) => {
+    setToasts((current) => current.filter((toast) => toast.id !== id));
+  }, []);
+
+  const addToast = useCallback((kind: ToastKind, options: ToastOptions) => {
+    const id = ++toastIdRef.current;
+    const timeoutMs =
+      options.timeoutMs ??
+      (kind === "error" ? ERROR_TOAST_TIMEOUT_MS : DEFAULT_TOAST_TIMEOUT_MS);
+
+    setToasts((current) => [...current, { ...options, kind, id, timeoutMs }]);
+
+    window.setTimeout(() => {
+      dismissToast(id);
+    }, timeoutMs);
+  }, [dismissToast]);
+
+  const showNextConfirm = useCallback(() => {
+    const queued = confirmQueueRef.current.shift() ?? null;
+    setActiveConfirm(queued);
+  }, []);
+
+  const confirm = useCallback((options: ConfirmOptions) => {
+    return new Promise<boolean>((resolve) => {
+      const request: ActiveConfirm = { ...options, resolve };
+
+      setActiveConfirm((current) => {
+        if (current) {
+          confirmQueueRef.current.push(request);
+          return current;
+        }
+
+        return request;
+      });
+    });
+  }, []);
+
+  const resolveConfirm = useCallback(
+    (value: boolean) => {
+      setActiveConfirm((current) => {
+        if (!current) return null;
+        current.resolve(value);
+        return null;
+      });
+      showNextConfirm();
+    },
+    [showNextConfirm]
+  );
+
+  const value = useMemo<AppUxContextValue>(
+    () => ({
+      notify: createNotificationApi(addToast),
+      confirm,
+    }),
+    [addToast, confirm]
+  );
+
+  return (
+    <AppUxContext.Provider value={value}>
+      {children}
+      <ToastViewport toasts={toasts} onDismiss={dismissToast} />
+      <ConfirmDialogHost
+        activeConfirm={activeConfirm}
+        onCancel={() => resolveConfirm(false)}
+        onConfirm={() => resolveConfirm(true)}
+      />
+    </AppUxContext.Provider>
+  );
+}
+
+export function useAppUx(): AppUxContextValue {
+  const context = useContext(AppUxContext);
+  if (!context) {
+    throw new Error("useAppUx must be used inside AppUxProvider");
+  }
+  return context;
+}
+
+function ToastViewport({
+  toasts,
+  onDismiss,
+}: {
+  toasts: ToastItem[];
+  onDismiss: (id: number) => void;
+}) {
+  return (
+    <div className="toast-viewport" aria-live="polite" aria-atomic="false">
+      {toasts.map((toast) => (
+        <div className={`toast toast-${toast.kind}`} key={toast.id} role="status">
+          <div className="toast-main">
+            <strong>{toast.title}</strong>
+            {toast.message ? <div>{toast.message}</div> : null}
+          </div>
+          <button
+            type="button"
+            className="toast-close"
+            onClick={() => onDismiss(toast.id)}
+            aria-label="Dismiss notification"
+          >
+            ×
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ConfirmDialogHost({
+  activeConfirm,
+  onCancel,
+  onConfirm,
+}: {
+  activeConfirm: ActiveConfirm | null;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const confirmButtonRef = useRef<HTMLButtonElement | null>(null);
+  const cancelButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    if (!activeConfirm) return;
+    cancelButtonRef.current?.focus();
+  }, [activeConfirm]);
+
+  useEffect(() => {
+    if (!activeConfirm) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onCancel();
+      }
+
+      if (event.key === "Enter" && activeConfirm.confirmOnEnter) {
+        event.preventDefault();
+        onConfirm();
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [activeConfirm, onCancel, onConfirm]);
+
+  if (!activeConfirm) return null;
+
+  return (
+    <div className="confirm-overlay" role="presentation">
+      <div className="confirm-dialog" role="dialog" aria-modal="true" aria-labelledby="confirm-title">
+        <h2 id="confirm-title">{activeConfirm.title}</h2>
+        <p>{activeConfirm.message}</p>
+
+        <div className="confirm-actions">
+          <button type="button" ref={cancelButtonRef} onClick={onCancel}>
+            {activeConfirm.cancelLabel ?? "Cancel"}
+          </button>
+          <button
+            type="button"
+            ref={confirmButtonRef}
+            className={activeConfirm.variant === "danger" ? "danger" : "primary"}
+            onClick={onConfirm}
+          >
+            {activeConfirm.confirmLabel ?? "Confirm"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -341,3 +341,126 @@ body {
 .status-dirty.is-saved {
   color: var(--color-text-muted);
 }
+
+/* ============================================================
+   Notifications and confirm dialog
+   ============================================================ */
+
+.toast-viewport {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  z-index: 50;
+  pointer-events: none;
+}
+
+.toast {
+  min-width: 260px;
+  max-width: 420px;
+  border-radius: 8px;
+  border: 1px solid var(--color-border);
+  background: #fff;
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.14);
+  padding: 10px 12px;
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  pointer-events: auto;
+}
+
+.toast-main {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+}
+
+.toast-main strong {
+  font-size: 13px;
+}
+
+.toast-info {
+  border-left: 4px solid #3b82f6;
+}
+
+.toast-success {
+  border-left: 4px solid #16a34a;
+}
+
+.toast-warning {
+  border-left: 4px solid #d97706;
+}
+
+.toast-error {
+  border-left: 4px solid #dc2626;
+}
+
+.toast-close {
+  border: none;
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+}
+
+.confirm-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.28);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 60;
+}
+
+.confirm-dialog {
+  width: min(440px, calc(100vw - 32px));
+  background: #fff;
+  border-radius: 10px;
+  border: 1px solid var(--color-border);
+  box-shadow: 0 15px 35px rgba(0, 0, 0, 0.24);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.confirm-dialog h2 {
+  font-size: 17px;
+}
+
+.confirm-dialog p {
+  font-size: 14px;
+  color: #555;
+}
+
+.confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.confirm-actions button {
+  padding: 6px 10px;
+  border-radius: 6px;
+  border: 1px solid var(--color-border);
+  background: #fff;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.confirm-actions button.primary {
+  background: #2563eb;
+  border-color: #2563eb;
+  color: #fff;
+}
+
+.confirm-actions button.danger {
+  background: #dc2626;
+  border-color: #dc2626;
+  color: #fff;
+}


### PR DESCRIPTION
### Motivation

- Replace scattered `alert`/`confirm` usage with a small internal UX layer for non-blocking notifications and a single confirm flow. 
- Surface common file operation results (save/open/reload) as gentle toasts instead of blocking dialogs while keeping the app MVP and stack unchanged. 
- Keep business logic in services and move only rendering/UI responsibilities into the app shell/controller layer. 

### Description

- Added a compact app UX provider `AppUxProvider` that exposes `notify.{info|success|warning|error}` and `confirm(options): Promise<boolean>` with queueing and basic keyboard handling in `src/features/ux/useAppUx.tsx`. 
- Mounted the UX provider around the app in `src/app/App.tsx` and added lightweight host components `ToastViewport` and `ConfirmDialogHost` (no layout redesign). 
- Refactored orchestration in `src/features/documents/fileActionService.ts` to use the `notify` API for success/error feedback and to provide `createDiscardChangesConfirmOptions()` for centralized discard prompts. 
- Replaced direct `window.confirm` usage in `src/features/editor/useEditorController.ts` with the centralized `confirm` API, added a guard against re-entrant close confirms, and surfaced close errors via `notify`. 
- Added minimal styles for toasts and confirm dialog in `src/styles.css` and intentionally left `window.prompt` usages for link/image entry unchanged in `src/features/editor/editorCommands.ts` to preserve MVP scope. 
- Changed/added files: `src/features/ux/useAppUx.tsx` (new), `src/app/App.tsx` (wrap with provider), `src/features/documents/fileActionService.ts` (notify integration + confirm options), `src/features/editor/useEditorController.ts` (confirm integration + close guard), and `src/styles.css` (styles for toast/confirm). 

### Testing

- Ran `npm run build` (which runs `tsc` and `vite build`) and the build completed successfully with artifacts produced. 
- No additional automated tests were added in this iteration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d57a873ddc8322ab81381acb3ce1d8)