### PR TITLE
Revise README: expand features, architecture, and getting-started docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,41 @@
 # mdedit
 
-A lightweight cross-platform WYSIWYG Markdown editor built with Tauri 2, React, TypeScript, and Tiptap — inspired by Typora.
+A lightweight cross-platform WYSIWYG Markdown editor built with **Tauri 2**, **React**, **TypeScript**, and **Tiptap** (Typora-inspired single-pane editing).
 
-## Features (MVP)
+## What the app does today
 
-- Open any `.md` file via the native file dialog
-- Edit in a clean single-pane WYSIWYG editor (Typora-style)
-- Toolbar for Bold, Italic, H1/H2, lists, blockquote, and code blocks
-- Save changes back to the original file or choose a new path via Save dialog
-- Unsaved-changes indicator in the status bar
-- Ctrl+S / ⌘+S keyboard shortcut
+- Open Markdown files (`.md`, `.markdown`, `.txt`) via native OS dialog.
+- Edit in a clean, single-pane WYSIWYG editor.
+- Save to the same path or via **Save As**.
+- Track dirty state (Saved/Modified) and show the active filename in the status bar.
+- Update the native window title (`*filename - mdedit` when modified).
+- Confirm before discarding unsaved changes (open/reload/close flow).
+- Detect external file changes (mtime check on app focus/visibility change) and highlight reload.
+- Keep a **Recent Files** list and reopen last file on startup (persisted in `localStorage`).
+- Provide toast notifications for open/save/reload flows and errors.
+- Offer toolbar actions for:
+  - Bold, italic, headings, ordered/bullet lists, blockquote, code block
+  - Links (insert/remove)
+  - Task list insertion
+  - Table insertion
+  - Image insertion via URL
+- Provide app menu items for File/Edit actions.
 
-## Stack
+## Keyboard shortcuts
+
+- `Ctrl/Cmd + O` → Open
+- `Ctrl/Cmd + S` → Save
+- `Ctrl/Cmd + Shift + S` → Save As
+- `Ctrl/Cmd + Alt + R` → Reload from disk
+
+## Tech stack
 
 | Layer | Technology |
 |---|---|
 | Desktop shell | Tauri 2 |
 | UI | React 18 + TypeScript |
 | Build | Vite 5 |
-| Editor | Tiptap (StarterKit) |
+| Editor | Tiptap + StarterKit + custom extensions |
 | App state | Zustand |
 | Markdown pipeline | unified / remark / rehype |
 | Native bridge | Custom Tauri commands + rfd |
@@ -37,71 +54,99 @@ sudo apt install libgtk-3-dev libwebkit2gtk-4.1-dev libssl-dev
 ## Getting started
 
 ```bash
-# 1. Install JavaScript dependencies
+# 1) Install JS dependencies
 npm install
 
-# 2. Start the development build (opens the app window)
+# 2) Run Vite + Tauri desktop app
 npm run tauri dev
 ```
 
-The first run will also compile the Rust binary (this can take a few minutes).
+First run also compiles the Rust backend, which can take a few minutes.
+
+## Build
+
+```bash
+# Frontend production build
+npm run build
+
+# (optional) Full desktop bundle
+npm run tauri build
+```
 
 ## Project structure
 
-```
+```text
 src/
-├── app/                    # Root App component
+├── app/                    # Root app composition
 ├── components/             # Layout, Toolbar, StatusBar
 ├── features/
-│   ├── editor/             # Tiptap EditorArea component
-│   └── documents/          # documentService (open / save orchestration)
-├── services/
-│   ├── tauriBridge.ts      # Typed wrappers around Tauri invoke()
-│   └── markdownService.ts  # Markdown ↔ HTML via unified/remark/rehype
-├── stores/
-│   └── documentStore.ts    # Zustand document state
-├── types/                  # Shared TypeScript types
+│   ├── documents/          # Open/save/reload orchestrators
+│   ├── editor/             # Tiptap editor + extensions + controller
+│   └── ux/                 # Toast + confirm dialog system
+├── services/               # Tauri bridge, markdown transform, app state storage
+├── stores/                 # Zustand document state
+├── types/                  # Shared app types
 └── lib/                    # Utility helpers
 
 src-tauri/
 ├── src/
-│   ├── main.rs             # Binary entry point
-│   └── lib.rs              # Tauri commands + app bootstrap
-├── capabilities/           # Tauri 2 window capability grants
-├── permissions/            # Tauri 2 custom command permissions
-└── tauri.conf.json         # Tauri configuration
+│   ├── main.rs             # Binary entrypoint
+│   └── lib.rs              # Tauri command handlers + bootstrap
+├── capabilities/           # Tauri v2 capability grants
+├── permissions/            # Custom command permissions
+└── tauri.conf.json         # Tauri app configuration
 ```
 
 ## Architecture overview
 
+```text
+┌──────────────────────────────────────────────────────┐
+│ UI / Presentation                                    │
+│ App · Toolbar · EditorArea · StatusBar · UX dialogs │
+├──────────────────────────────────────────────────────┤
+│ Application layer                                    │
+│ useEditorController · fileActionService             │
+│ documentService · appStateService                   │
+├──────────────────────────────────────────────────────┤
+│ State + conversion                                   │
+│ documentStore (Zustand) · markdownService           │
+├──────────────────────────────────────────────────────┤
+│ Native bridge (Tauri)                                │
+│ tauriBridge.ts → Rust commands (open/read/save/...) │
+└──────────────────────────────────────────────────────┘
 ```
-┌─────────────────────────────────────┐
-│  UI / Presentation                  │
-│  App · Toolbar · EditorArea ·       │
-│  StatusBar · Layout                 │
-├─────────────────────────────────────┤
-│  Application / Document Services   │
-│  documentService · markdownService  │
-│  documentStore (Zustand)            │
-├─────────────────────────────────────┤
-│  Native Desktop Bridge (Tauri)      │
-│  tauriBridge.ts → Rust commands     │
-│  open_file_dialog · read_text_file  │
-│  save_text_file · save_file_dialog  │
-└─────────────────────────────────────┘
-```
 
-## Next recommended steps
+## Markdown processing model
 
-The following are **not** implemented yet and are suggested for the next iteration:
+The editor flow uses three representations:
 
-1. **Window title** – reflect open filename and dirty state in the OS title bar
-2. **Close / quit confirmation** – prompt when quitting with unsaved changes
-3. **Recent files** – persist a list of recently opened paths
-4. **Code block syntax highlighting** – add `@tiptap/extension-code-block-lowlight` with lowlight
-5. **Image support** – drag-and-drop or paste images, store as base64 or relative paths
-6. **Lossless Markdown roundtrip** – investigate Tiptap's `@tiptap/extension-markdown` for better serialisation
-7. **Keyboard shortcuts** – additional shortcuts (e.g. Ctrl+O for Open)
-8. **Theming** – light/dark mode toggle
-9. **App icons** – replace the empty icon array with proper platform icons
-10. **Tests** – add Vitest for service-layer unit tests
+1. **Raw markdown** loaded from disk.
+2. **Editor HTML** rendered in Tiptap.
+3. **Canonical markdown** generated from editor HTML and used for dirty checks + save.
+
+> Note: current HTML ↔ Markdown conversion is intentionally practical for MVP, not fully lossless for every markdown edge case.
+
+## Persistence behavior
+
+App-level state is stored in browser storage (`localStorage`) under `mdedit.appState.v1`:
+
+- recent files list (deduplicated, max 10)
+- last opened path
+- startup behavior flag (`reopenLastFileOnStartup`)
+
+## TODO
+
+- [x] **Window title** – reflect open filename and dirty state in the OS title bar
+- [x] **Close / quit confirmation** – prompt when quitting with unsaved changes
+- [x] **Recent files** – persist a list of recently opened paths
+- [ ] **Code block syntax highlighting** – add `@tiptap/extension-code-block-lowlight` with lowlight
+- [ ] **Image support** – improve beyond URL insertion (e.g., drag-and-drop/paste + local asset handling)
+- [ ] **Lossless Markdown roundtrip** – investigate Tiptap's `@tiptap/extension-markdown` for better serialisation
+- [x] **Keyboard shortcuts** – additional shortcuts (Open/Save/Save As/Reload)
+- [ ] **Theming** – light/dark mode toggle
+- [ ] **App icons** – replace the empty icon array with proper platform icons
+- [ ] **Tests** – add Vitest for service-layer unit tests
+
+## License
+
+MIT (see `LICENSE`).


### PR DESCRIPTION
### Motivation

- Provide a more complete, user-focused README that documents current capabilities, usage, and developer workflow. 
- Clarify the project architecture and project layout for contributors and maintainers. 
- Add explicit build and run instructions and enumerate keyboard shortcuts and persistence behavior. 

### Description

- Rewrote and expanded `README.md` to list supported file types, feature set, toolbar actions, and keyboard shortcuts. 
- Added explicit `Build` and `Getting started` instructions with commands such as `npm run tauri dev`, `npm run build`, and `npm run tauri build`. 
- Updated the `Tech stack` and `Project structure` sections to reflect implementation details like custom Tiptap extensions, Zustand stores, and Tauri command handlers. 
- Introduced an `Architecture overview`, `Markdown processing model`, and `Persistence behavior` section, and updated the `TODO` list and license note. 

### Testing

- No automated tests were added or executed as part of this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d57cd405148322b675fa730821f100)