### PR TITLE
Add reusable input dialog to UX layer and replace prompt-based link/image flows

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -17,6 +17,9 @@ function AppContent() {
     handleReload,
     handleSave,
     handleSaveAs,
+    handleInsertLink,
+    handleRemoveLink,
+    handleInsertImage,
   } = useEditorController();
 
   return (
@@ -29,6 +32,9 @@ function AppContent() {
         onReload={() => void handleReload()}
         onSave={() => void handleSave()}
         onSaveAs={() => void handleSaveAs()}
+        onInsertLink={() => void handleInsertLink()}
+        onRemoveLink={handleRemoveLink}
+        onInsertImage={() => void handleInsertImage()}
         canReload={Boolean(currentFilePath)}
         highlightReload={activeDocument.hasExternalChangeWarning}
       />

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -3,13 +3,7 @@
  */
 import type { Editor } from "@tiptap/react";
 
-import {
-  insertDefaultTable,
-  insertImage,
-  insertLink,
-  insertTaskList,
-  removeLink,
-} from "../features/editor/editorCommands";
+import { insertDefaultTable, insertTaskList } from "../features/editor/editorCommands";
 import { basename } from "../lib/utils";
 
 interface ToolbarProps {
@@ -20,6 +14,9 @@ interface ToolbarProps {
   onReload: () => void;
   onSave: () => void;
   onSaveAs: () => void;
+  onInsertLink: () => void;
+  onRemoveLink: () => void;
+  onInsertImage: () => void;
   canReload: boolean;
   highlightReload: boolean;
 }
@@ -32,6 +29,9 @@ export default function Toolbar({
   onReload,
   onSave,
   onSaveAs,
+  onInsertLink,
+  onRemoveLink,
+  onInsertImage,
   canReload,
   highlightReload,
 }: ToolbarProps) {
@@ -163,7 +163,7 @@ export default function Toolbar({
         </button>
 
         <button
-          onClick={() => editor && insertLink(editor)}
+          onClick={onInsertLink}
           className={editor?.isActive("link") ? "active" : ""}
           disabled={!editor}
           title="Add link"
@@ -172,7 +172,7 @@ export default function Toolbar({
         </button>
 
         <button
-          onClick={() => editor && removeLink(editor)}
+          onClick={onRemoveLink}
           disabled={!editor || !editor.isActive("link")}
           title="Remove link"
         >
@@ -198,7 +198,7 @@ export default function Toolbar({
         </button>
 
         <button
-          onClick={() => editor && insertImage(editor)}
+          onClick={onInsertImage}
           disabled={!editor}
           title="Insert image from URL"
         >

--- a/src/features/editor/editorCommands.ts
+++ b/src/features/editor/editorCommands.ts
@@ -1,12 +1,45 @@
 import type { Editor } from "@tiptap/react";
 
-export function insertLink(editor: Editor): void {
+import type { InputDialogOptions } from "../ux/useAppUx";
+
+type RequestInput = (options: InputDialogOptions) => Promise<string | null>;
+
+function normalizeUrl(rawValue: string): string {
+  const value = rawValue.trim();
+  if (!value) return "";
+
+  const hasScheme = /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(value);
+  const isAnchor = value.startsWith("#");
+  const isAbsolutePath = value.startsWith("/");
+
+  if (hasScheme || isAnchor || isAbsolutePath) {
+    return value;
+  }
+
+  return `https://${value}`;
+}
+
+function requireNonEmpty(value: string): string | null {
+  return value.trim() ? null : "This field cannot be empty.";
+}
+
+export async function insertLink(editor: Editor, requestInput: RequestInput): Promise<void> {
   const existingHref = editor.getAttributes("link").href as string | undefined;
-  const url = window.prompt("Enter link URL", existingHref ?? "https://");
+  const enteredUrl = await requestInput({
+    title: "Insert link",
+    message: "Enter the destination URL.",
+    label: "Link URL",
+    placeholder: "https://example.com",
+    initialValue: existingHref ?? "https://",
+    confirmLabel: "Apply link",
+    cancelLabel: "Cancel",
+    confirmOnEnter: true,
+    validation: requireNonEmpty,
+  });
 
-  if (!url) return;
+  if (enteredUrl === null) return;
 
-  const normalizedUrl = url.trim();
+  const normalizedUrl = normalizeUrl(enteredUrl);
   if (!normalizedUrl) return;
 
   if (editor.state.selection.empty) {
@@ -28,15 +61,46 @@ export function removeLink(editor: Editor): void {
   editor.chain().focus().extendMarkRange("link").unsetMark("link").run();
 }
 
-export function insertImage(editor: Editor): void {
-  const src = window.prompt("Enter image URL", "https://");
-  if (!src) return;
+export async function insertImage(editor: Editor, requestInput: RequestInput): Promise<void> {
+  const enteredUrl = await requestInput({
+    title: "Insert image",
+    message: "Enter an image URL.",
+    label: "Image URL",
+    placeholder: "https://example.com/image.png",
+    initialValue: "https://",
+    confirmLabel: "Continue",
+    cancelLabel: "Cancel",
+    confirmOnEnter: true,
+    validation: requireNonEmpty,
+  });
 
-  const normalizedSrc = src.trim();
+  if (enteredUrl === null) return;
+
+  const normalizedSrc = normalizeUrl(enteredUrl);
   if (!normalizedSrc) return;
 
-  const alt = window.prompt("Alt text (optional)", "") ?? "";
-  editor.chain().focus().insertContent({ type: "image", attrs: { src: normalizedSrc, alt: alt.trim() || null } }).run();
+  const alt = await requestInput({
+    title: "Image alt text",
+    message: "Add optional alt text for accessibility.",
+    label: "Alt text",
+    placeholder: "Describe the image (optional)",
+    initialValue: "",
+    confirmLabel: "Insert image",
+    cancelLabel: "Skip",
+    confirmOnEnter: true,
+  });
+
+  editor
+    .chain()
+    .focus()
+    .insertContent({
+      type: "image",
+      attrs: {
+        src: normalizedSrc,
+        alt: alt === null ? null : alt.trim() || null,
+      },
+    })
+    .run();
 }
 
 export function insertTaskList(editor: Editor): void {

--- a/src/features/editor/useEditorController.ts
+++ b/src/features/editor/useEditorController.ts
@@ -29,6 +29,7 @@ import {
   createDiscardChangesConfirmOptions,
 } from "../documents/fileActionService";
 import { reconcileCanonicalFromEditorHtml } from "../documents/documentService";
+import { insertImage, insertLink, removeLink } from "./editorCommands";
 
 const APP_NAME = "mdedit";
 const RELOAD_ACCELERATOR = "CmdOrCtrl+Alt+R";
@@ -53,6 +54,9 @@ export interface EditorController {
   handleReload: () => Promise<void>;
   handleSave: () => Promise<void>;
   handleSaveAs: () => Promise<void>;
+  handleInsertLink: () => Promise<void>;
+  handleRemoveLink: () => void;
+  handleInsertImage: () => Promise<void>;
 }
 
 export function useEditorController(): EditorController {
@@ -63,7 +67,7 @@ export function useEditorController(): EditorController {
   const startupReopenDoneRef = useRef(false);
   const [persistedState, setPersistedState] = useState(getInitialPersistedState);
   const { isDirty, currentFilePath } = useDocumentStore();
-  const { confirm, notify } = useAppUx();
+  const { confirm, notify, requestInput } = useAppUx();
 
   const editor = useEditor({
     extensions: [
@@ -138,6 +142,21 @@ export function useEditorController(): EditorController {
   const handleSaveAs = useCallback(async () => {
     await runSaveAsAction(actionContext);
   }, [actionContext]);
+
+  const handleInsertLink = useCallback(async () => {
+    if (!editor) return;
+    await insertLink(editor, requestInput);
+  }, [editor, requestInput]);
+
+  const handleRemoveLink = useCallback(() => {
+    if (!editor) return;
+    removeLink(editor);
+  }, [editor]);
+
+  const handleInsertImage = useCallback(async () => {
+    if (!editor) return;
+    await insertImage(editor, requestInput);
+  }, [editor, requestInput]);
 
   useEffect(() => {
     if (!editor || startupReopenDoneRef.current) return;
@@ -377,6 +396,9 @@ export function useEditorController(): EditorController {
       handleReload,
       handleSave,
       handleSaveAs,
+      handleInsertLink,
+      handleRemoveLink,
+      handleInsertImage,
     }),
     [
       editor,
@@ -385,6 +407,9 @@ export function useEditorController(): EditorController {
       handleReload,
       handleSave,
       handleSaveAs,
+      handleInsertLink,
+      handleRemoveLink,
+      handleInsertImage,
       persistedState.recentFiles,
     ]
   );

--- a/src/features/ux/useAppUx.tsx
+++ b/src/features/ux/useAppUx.tsx
@@ -6,6 +6,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type FormEvent,
   type ReactNode,
 } from "react";
 
@@ -26,6 +27,18 @@ export interface ConfirmOptions {
   confirmOnEnter?: boolean;
 }
 
+export interface InputDialogOptions {
+  title: string;
+  message?: string;
+  label?: string;
+  placeholder?: string;
+  initialValue?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  confirmOnEnter?: boolean;
+  validation?: (value: string) => string | null;
+}
+
 interface ToastItem extends ToastOptions {
   id: number;
   kind: ToastKind;
@@ -35,6 +48,14 @@ interface ActiveConfirm extends ConfirmOptions {
   resolve: (value: boolean) => void;
 }
 
+interface ActiveInputDialog extends InputDialogOptions {
+  resolve: (value: string | null) => void;
+}
+
+type ActiveDialogRequest =
+  | { kind: "confirm"; payload: ActiveConfirm }
+  | { kind: "input"; payload: ActiveInputDialog };
+
 interface AppUxContextValue {
   notify: {
     info: (options: ToastOptions) => void;
@@ -43,6 +64,7 @@ interface AppUxContextValue {
     error: (options: ToastOptions) => void;
   };
   confirm: (options: ConfirmOptions) => Promise<boolean>;
+  requestInput: (options: InputDialogOptions) => Promise<string | null>;
 }
 
 const AppUxContext = createContext<AppUxContextValue | null>(null);
@@ -61,9 +83,10 @@ function createNotificationApi(addToast: (kind: ToastKind, options: ToastOptions
 
 export function AppUxProvider({ children }: { children: ReactNode }) {
   const [toasts, setToasts] = useState<ToastItem[]>([]);
-  const [activeConfirm, setActiveConfirm] = useState<ActiveConfirm | null>(null);
+  const [activeDialog, setActiveDialog] = useState<ActiveDialogRequest | null>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
   const toastIdRef = useRef(0);
-  const confirmQueueRef = useRef<ActiveConfirm[]>([]);
+  const dialogQueueRef = useRef<ActiveDialogRequest[]>([]);
 
   const dismissToast = useCallback((id: number) => {
     setToasts((current) => current.filter((toast) => toast.id !== id));
@@ -82,44 +105,76 @@ export function AppUxProvider({ children }: { children: ReactNode }) {
     }, timeoutMs);
   }, [dismissToast]);
 
-  const showNextConfirm = useCallback(() => {
-    const queued = confirmQueueRef.current.shift() ?? null;
-    setActiveConfirm(queued);
+  const showNextDialog = useCallback(() => {
+    const queued = dialogQueueRef.current.shift() ?? null;
+    setActiveDialog(queued);
+  }, []);
+
+  const enqueueDialog = useCallback((request: ActiveDialogRequest) => {
+    setActiveDialog((current) => {
+      if (current) {
+        dialogQueueRef.current.push(request);
+        return current;
+      }
+
+      return request;
+    });
   }, []);
 
   const confirm = useCallback((options: ConfirmOptions) => {
     return new Promise<boolean>((resolve) => {
-      const request: ActiveConfirm = { ...options, resolve };
-
-      setActiveConfirm((current) => {
-        if (current) {
-          confirmQueueRef.current.push(request);
-          return current;
-        }
-
-        return request;
-      });
+      enqueueDialog({ kind: "confirm", payload: { ...options, resolve } });
     });
-  }, []);
+  }, [enqueueDialog]);
 
-  const resolveConfirm = useCallback(
+  const requestInput = useCallback((options: InputDialogOptions) => {
+    return new Promise<string | null>((resolve) => {
+      enqueueDialog({ kind: "input", payload: { ...options, resolve } });
+    });
+  }, [enqueueDialog]);
+
+  const closeDialog = useCallback(() => {
+    setActiveDialog(null);
+    showNextDialog();
+  }, [showNextDialog]);
+
+  const resolveActiveConfirm = useCallback(
     (value: boolean) => {
-      setActiveConfirm((current) => {
-        if (!current) return null;
-        current.resolve(value);
-        return null;
-      });
-      showNextConfirm();
+      if (activeDialog?.kind !== "confirm") return;
+      activeDialog.payload.resolve(value);
+      closeDialog();
     },
-    [showNextConfirm]
+    [activeDialog, closeDialog]
   );
+
+  const resolveActiveInput = useCallback(
+    (value: string | null) => {
+      if (activeDialog?.kind !== "input") return;
+      activeDialog.payload.resolve(value);
+      closeDialog();
+    },
+    [activeDialog, closeDialog]
+  );
+
+  useEffect(() => {
+    if (!activeDialog) {
+      previousFocusRef.current?.focus();
+      previousFocusRef.current = null;
+      return;
+    }
+
+    previousFocusRef.current = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+  }, [activeDialog]);
 
   const value = useMemo<AppUxContextValue>(
     () => ({
       notify: createNotificationApi(addToast),
       confirm,
+      requestInput,
     }),
-    [addToast, confirm]
+    [addToast, confirm, requestInput]
   );
 
   return (
@@ -127,9 +182,14 @@ export function AppUxProvider({ children }: { children: ReactNode }) {
       {children}
       <ToastViewport toasts={toasts} onDismiss={dismissToast} />
       <ConfirmDialogHost
-        activeConfirm={activeConfirm}
-        onCancel={() => resolveConfirm(false)}
-        onConfirm={() => resolveConfirm(true)}
+        activeConfirm={activeDialog?.kind === "confirm" ? activeDialog.payload : null}
+        onCancel={() => resolveActiveConfirm(false)}
+        onConfirm={() => resolveActiveConfirm(true)}
+      />
+      <InputDialogHost
+        activeInput={activeDialog?.kind === "input" ? activeDialog.payload : null}
+        onCancel={() => resolveActiveInput(null)}
+        onConfirm={resolveActiveInput}
       />
     </AppUxContext.Provider>
   );
@@ -230,6 +290,107 @@ function ConfirmDialogHost({
           </button>
         </div>
       </div>
+    </div>
+  );
+}
+
+function InputDialogHost({
+  activeInput,
+  onCancel,
+  onConfirm,
+}: {
+  activeInput: ActiveInputDialog | null;
+  onCancel: () => void;
+  onConfirm: (value: string) => void;
+}) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [value, setValue] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!activeInput) {
+      setValue("");
+      setError(null);
+      return;
+    }
+
+    setValue(activeInput.initialValue ?? "");
+    setError(null);
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, [activeInput]);
+
+  useEffect(() => {
+    if (!activeInput) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      onCancel();
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [activeInput, onCancel]);
+
+  if (!activeInput) return null;
+
+  const validate = (candidate: string) => activeInput.validation?.(candidate) ?? null;
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    const nextError = validate(value);
+
+    if (nextError) {
+      setError(nextError);
+      return;
+    }
+
+    onConfirm(value);
+  };
+
+  return (
+    <div className="confirm-overlay" role="presentation">
+      <form
+        className="confirm-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="input-title"
+        onSubmit={handleSubmit}
+      >
+        <h2 id="input-title">{activeInput.title}</h2>
+        {activeInput.message ? <p>{activeInput.message}</p> : null}
+
+        <label className="dialog-input-label">
+          {activeInput.label ?? "Value"}
+          <input
+            ref={inputRef}
+            className="dialog-input"
+            placeholder={activeInput.placeholder}
+            value={value}
+            onChange={(event) => {
+              setValue(event.target.value);
+              if (error) setError(null);
+            }}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" && activeInput.confirmOnEnter === false) {
+                event.preventDefault();
+              }
+            }}
+          />
+        </label>
+
+        {error ? <p className="dialog-input-error">{error}</p> : null}
+
+        <div className="confirm-actions">
+          <button type="button" onClick={onCancel}>
+            {activeInput.cancelLabel ?? "Cancel"}
+          </button>
+          <button type="submit" className="primary">
+            {activeInput.confirmLabel ?? "Confirm"}
+          </button>
+        </div>
+      </form>
     </div>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -442,6 +442,34 @@ body {
   display: flex;
   justify-content: flex-end;
   gap: 8px;
+  margin-top: 4px;
+}
+
+
+.dialog-input-label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 13px;
+  color: #444;
+}
+
+.dialog-input {
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  padding: 8px 10px;
+  font-size: 13px;
+  font-family: var(--font-ui);
+}
+
+.dialog-input:focus {
+  outline: 2px solid rgba(37, 99, 235, 0.22);
+  border-color: #2563eb;
+}
+
+.dialog-input-error {
+  font-size: 12px;
+  color: #dc2626;
 }
 
 .confirm-actions button {


### PR DESCRIPTION
### Motivation

- Remove remaining `window.prompt` usages and centralize simple input dialogs in the existing UX layer to keep UI components dumb and preserve current architecture. 
- Provide a small, typed, reusable `requestInput` API consistent with the existing `confirm` API to power link and image workflows. 
- Keep the implementation minimal (no new modal framework or form builder) and visually consistent with the existing confirm/toast UI.

### Description

- Introduce a typed single-input dialog API `requestInput(options): Promise<string | null>` on the UX provider and shared queuing so confirms and inputs do not overlap, with autofocus, Enter/Escape handling, inline validation, and focus return; implemented in `src/features/ux/useAppUx.tsx`.
- Replace `window.prompt` in editor commands with `requestInput` and lightweight URL helpers: added `normalizeUrl` and `requireNonEmpty` plus async flows for link and image insertions in `src/features/editor/editorCommands.ts`.
- Move orchestration into the editor controller so the toolbar stays UI-only: `useEditorController` now exposes `handleInsertLink`, `handleRemoveLink`, and `handleInsertImage` which call the new editor command functions using `requestInput` from `useAppUx`; changes in `src/features/editor/useEditorController.ts` and `src/app/App.tsx`.
- Update `Toolbar` props to call the new handlers and add minimal dialog styling (label, input, inline error, action spacing) in `src/components/Toolbar.tsx` and `src/styles.css` to visually match the existing confirm dialog.

### Testing

- Ran the project build with `npm run build`, which failed due to an existing repository dependency/type issue: `src/services/markdownService.ts(15,23): error TS2307: Cannot find module 'remark-gfm' or its corresponding type declarations.`, so the new changes were not fully validated via a successful production build in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5804c9c9c832291c2e1b0c51aab0c)