### PR TITLE
Add untitled document workflow (New action + empty state)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -12,6 +12,8 @@ function AppContent() {
   const {
     editor,
     recentFiles,
+    hasActiveDocument,
+    handleNew,
     handleOpen,
     handleOpenRecent,
     handleReload,
@@ -26,6 +28,7 @@ function AppContent() {
     <Layout>
       <Toolbar
         editor={editor}
+        onNew={() => void handleNew()}
         onOpen={() => void handleOpen()}
         onOpenRecent={(path) => void handleOpenRecent(path)}
         recentFiles={recentFiles}
@@ -38,10 +41,18 @@ function AppContent() {
         canReload={Boolean(currentFilePath)}
         highlightReload={activeDocument.hasExternalChangeWarning}
       />
-      <EditorArea editor={editor} />
+      <EditorArea
+        editor={editor}
+        showEmptyState={!hasActiveDocument}
+        recentFiles={recentFiles}
+        onNew={() => void handleNew()}
+        onOpen={() => void handleOpen()}
+        onOpenRecent={(path) => void handleOpenRecent(path)}
+      />
       <StatusBar
         isDirty={isDirty}
         filePath={currentFilePath}
+        hasActiveDocument={hasActiveDocument}
         hasExternalChangeWarning={activeDocument.hasExternalChangeWarning}
       />
     </Layout>

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -6,15 +6,21 @@ import { basename } from "../lib/utils";
 interface StatusBarProps {
   isDirty: boolean;
   filePath: string | null;
+  hasActiveDocument: boolean;
   hasExternalChangeWarning: boolean;
 }
 
 export default function StatusBar({
   isDirty,
   filePath,
+  hasActiveDocument,
   hasExternalChangeWarning,
 }: StatusBarProps) {
-  const filename = filePath ? basename(filePath) : "Untitled";
+  const filename = filePath
+    ? basename(filePath)
+    : hasActiveDocument
+      ? "Untitled"
+      : "No document";
   const dirtyLabel = isDirty ? "Modified" : "Saved";
 
   return (

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -8,6 +8,7 @@ import { basename } from "../lib/utils";
 
 interface ToolbarProps {
   editor: Editor | null;
+  onNew: () => void;
   onOpen: () => void;
   onOpenRecent: (path: string) => void;
   recentFiles: string[];
@@ -23,6 +24,7 @@ interface ToolbarProps {
 
 export default function Toolbar({
   editor,
+  onNew,
   onOpen,
   onOpenRecent,
   recentFiles,
@@ -38,6 +40,9 @@ export default function Toolbar({
   return (
     <div className="toolbar" role="toolbar" aria-label="Editor toolbar">
       <div className="toolbar-group">
+        <button onClick={onNew} title="New document (Ctrl/Cmd+N)">
+          New
+        </button>
         <button onClick={onOpen} title="Open Markdown file (Ctrl/Cmd+O)">
           Open
         </button>

--- a/src/features/documents/documentService.ts
+++ b/src/features/documents/documentService.ts
@@ -17,6 +17,8 @@ import type {
 } from "../../types";
 
 export type ConfirmDiscardChanges = () => Promise<boolean>;
+export const EMPTY_UNTITLED_EDITOR_HTML = "<p></p>";
+export const EMPTY_UNTITLED_CANONICAL_MARKDOWN = "\n";
 
 interface OpenDocumentOptions {
   confirmDiscardChanges?: ConfirmDiscardChanges;
@@ -87,6 +89,15 @@ export async function openDocumentFromPath(
 
     return { kind: "error", message, path: filePath };
   }
+}
+
+/** Creates a fresh untitled document baseline. */
+export function createNewUntitledDocument(): { html: string } {
+  useDocumentStore.getState().markNewUntitled({
+    canonicalMarkdown: EMPTY_UNTITLED_CANONICAL_MARKDOWN,
+  });
+
+  return { html: EMPTY_UNTITLED_EDITOR_HTML };
 }
 
 /** Save flow. If no file path exists, falls back to Save As. */

--- a/src/features/documents/fileActionService.ts
+++ b/src/features/documents/fileActionService.ts
@@ -5,6 +5,7 @@ import {
   type PersistedAppState,
 } from "../../services/appStateService";
 import {
+  createNewUntitledDocument,
   openDocument,
   openDocumentFromPath,
   reloadDocumentFromDisk,
@@ -13,6 +14,7 @@ import {
   type ConfirmDiscardChanges,
 } from "./documentService";
 import type { ConfirmOptions, ToastOptions } from "../ux/useAppUx";
+import { useDocumentStore } from "../../stores/documentStore";
 
 interface NotificationApi {
   info: (options: ToastOptions) => void;
@@ -55,6 +57,27 @@ export async function runOpenAction(
   } catch (error) {
     context.notify.error({
       title: "Open failed",
+      message: error instanceof Error ? error.message : "Unknown error.",
+    });
+  }
+}
+
+export async function runNewAction(context: FileActionContext): Promise<void> {
+  try {
+    const { isDirty } = useDocumentStore.getState();
+
+    if (isDirty) {
+      const canDiscard = await context.confirmDiscardChanges();
+      if (!canDiscard) {
+        return;
+      }
+    }
+
+    const result = createNewUntitledDocument();
+    context.setEditorHtml(result.html);
+  } catch (error) {
+    context.notify.error({
+      title: "New document failed",
       message: error instanceof Error ? error.message : "Unknown error.",
     });
   }

--- a/src/features/editor/Editor.tsx
+++ b/src/features/editor/Editor.tsx
@@ -6,12 +6,55 @@
  * through extra wrapper components.
  */
 import { EditorContent, type Editor } from "@tiptap/react";
+import { basename } from "../../lib/utils";
 
 interface EditorProps {
   editor: Editor | null;
+  showEmptyState: boolean;
+  recentFiles: string[];
+  onNew: () => void;
+  onOpen: () => void;
+  onOpenRecent: (path: string) => void;
 }
 
-export default function EditorArea({ editor }: EditorProps) {
+export default function EditorArea({
+  editor,
+  showEmptyState,
+  recentFiles,
+  onNew,
+  onOpen,
+  onOpenRecent,
+}: EditorProps) {
+  if (showEmptyState) {
+    return (
+      <div className="editor-wrapper empty-state-shell">
+        <div className="empty-state-panel">
+          <h1>mdedit</h1>
+          <p>Start a new document or open an existing Markdown file.</p>
+          <div className="empty-state-actions">
+            <button onClick={onNew}>New</button>
+            <button onClick={onOpen}>Open</button>
+          </div>
+          {recentFiles.length > 0 ? (
+            <ul className="empty-state-recent-list" aria-label="Recent files">
+              {recentFiles.slice(0, 5).map((path) => (
+                <li key={path}>
+                  <button
+                    className="empty-state-recent-item"
+                    onClick={() => onOpenRecent(path)}
+                    title={path}
+                  >
+                    {basename(path)}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="editor-wrapper">
       <EditorContent editor={editor} className="editor-content" />

--- a/src/features/editor/useEditorController.ts
+++ b/src/features/editor/useEditorController.ts
@@ -20,6 +20,7 @@ import { useAppUx } from "../ux/useAppUx";
 import { useDocumentStore } from "../../stores/documentStore";
 import {
   getInitialPersistedState,
+  runNewAction,
   runOpenAction,
   runOpenRecentAction,
   runReloadAction,
@@ -34,22 +35,27 @@ import { insertImage, insertLink, removeLink } from "./editorCommands";
 const APP_NAME = "mdedit";
 const RELOAD_ACCELERATOR = "CmdOrCtrl+Alt+R";
 
-const WELCOME_HTML = `
-<h1>Welcome to mdedit</h1>
-<p>A lightweight WYSIWYG Markdown editor. Click <strong>Open</strong> in the toolbar to load a <code>.md</code> file, or start typing here.</p>
-`;
+const UNTITLED_NAME = "Untitled";
 
-function buildWindowTitle(path: string | null, isDirty: boolean): string {
-  if (!path) return APP_NAME;
+function buildWindowTitle(params: {
+  path: string | null;
+  isDirty: boolean;
+  isUntitled: boolean;
+}): string {
+  const { path, isDirty, isUntitled } = params;
+  if (!path && !isUntitled) return APP_NAME;
+  if (!path && isUntitled) {
+    return `${isDirty ? "*" : ""}${UNTITLED_NAME} - ${APP_NAME}`;
+  }
   const prefix = isDirty ? "*" : "";
-  return `${prefix}${basename(path)} - ${APP_NAME}`;
+  return `${prefix}${basename(path ?? "")} - ${APP_NAME}`;
 }
-
-
 export interface EditorController {
   editor: Editor | null;
   recentFiles: string[];
+  hasActiveDocument: boolean;
   handleOpen: () => Promise<void>;
+  handleNew: () => Promise<void>;
   handleOpenRecent: (path: string) => Promise<void>;
   handleReload: () => Promise<void>;
   handleSave: () => Promise<void>;
@@ -66,7 +72,8 @@ export function useEditorController(): EditorController {
   const reconcileRunIdRef = useRef(0);
   const startupReopenDoneRef = useRef(false);
   const [persistedState, setPersistedState] = useState(getInitialPersistedState);
-  const { isDirty, currentFilePath } = useDocumentStore();
+  const { isDirty, currentFilePath, isUntitled, hasActiveDocument } =
+    useDocumentStore();
   const { confirm, notify, requestInput } = useAppUx();
 
   const editor = useEditor({
@@ -81,7 +88,7 @@ export function useEditorController(): EditorController {
       TableHeaderNode,
       TableCellNode,
     ],
-    content: WELCOME_HTML,
+    content: "",
     onUpdate: ({ editor: nextEditor }) => {
       if (isApplyingRemoteContent.current) return;
 
@@ -122,6 +129,10 @@ export function useEditorController(): EditorController {
 
   const handleOpen = useCallback(async () => {
     await runOpenAction(actionContext);
+  }, [actionContext]);
+
+  const handleNew = useCallback(async () => {
+    await runNewAction(actionContext);
   }, [actionContext]);
 
   const handleOpenRecent = useCallback(
@@ -171,7 +182,10 @@ export function useEditorController(): EditorController {
 
       const key = event.key.toLowerCase();
 
-      if (key === "o" && !event.shiftKey) {
+      if (key === "n" && !event.shiftKey) {
+        event.preventDefault();
+        void handleNew();
+      } else if (key === "o" && !event.shiftKey) {
         event.preventDefault();
         void handleOpen();
       } else if (key === "s" && event.shiftKey) {
@@ -188,7 +202,7 @@ export function useEditorController(): EditorController {
 
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [handleOpen, handleReload, handleSave, handleSaveAs]);
+  }, [handleNew, handleOpen, handleReload, handleSave, handleSaveAs]);
 
   useEffect(() => {
     let disposed = false;
@@ -213,6 +227,12 @@ export function useEditorController(): EditorController {
           text: "File",
           items: [
             {
+              id: "file-new",
+              text: "New",
+              accelerator: "CmdOrCtrl+N",
+              action: () => void handleNew(),
+            },
+            {
               id: "file-open",
               text: "Open…",
               accelerator: "CmdOrCtrl+O",
@@ -234,6 +254,7 @@ export function useEditorController(): EditorController {
               id: "file-reload",
               text: "Reload from disk",
               accelerator: RELOAD_ACCELERATOR,
+              enabled: Boolean(currentFilePath),
               action: () => void handleReload(),
             },
             await PredefinedMenuItem.new({ item: "Separator" }),
@@ -274,12 +295,25 @@ export function useEditorController(): EditorController {
     return () => {
       disposed = true;
     };
-  }, [handleOpen, handleOpenRecent, handleReload, handleSave, handleSaveAs, persistedState.recentFiles]);
+  }, [
+    currentFilePath,
+    handleNew,
+    handleOpen,
+    handleOpenRecent,
+    handleReload,
+    handleSave,
+    handleSaveAs,
+    persistedState.recentFiles,
+  ]);
 
   useEffect(() => {
-    const title = buildWindowTitle(currentFilePath, isDirty);
+    const title = buildWindowTitle({
+      path: currentFilePath,
+      isDirty,
+      isUntitled,
+    });
     void bridge.setWindowTitle(title);
-  }, [currentFilePath, isDirty]);
+  }, [currentFilePath, isDirty, isUntitled]);
 
   useEffect(() => {
     const onBeforeUnload = (event: BeforeUnloadEvent) => {
@@ -391,7 +425,9 @@ export function useEditorController(): EditorController {
     () => ({
       editor,
       recentFiles: persistedState.recentFiles,
+      hasActiveDocument,
       handleOpen,
+      handleNew,
       handleOpenRecent,
       handleReload,
       handleSave,
@@ -403,6 +439,7 @@ export function useEditorController(): EditorController {
     [
       editor,
       handleOpen,
+      handleNew,
       handleOpenRecent,
       handleReload,
       handleSave,
@@ -410,6 +447,7 @@ export function useEditorController(): EditorController {
       handleInsertLink,
       handleRemoveLink,
       handleInsertImage,
+      hasActiveDocument,
       persistedState.recentFiles,
     ]
   );

--- a/src/stores/documentStore.ts
+++ b/src/stores/documentStore.ts
@@ -3,6 +3,7 @@ import type { ActiveDocument, DocumentStore } from "../types";
 import { basename } from "../lib/utils";
 
 const EMPTY_DOCUMENT: ActiveDocument = {
+  kind: "none",
   path: null,
   name: null,
   rawLoadedContent: "",
@@ -15,6 +16,7 @@ const EMPTY_DOCUMENT: ActiveDocument = {
   lastReloadedAt: null,
   lastObservedDiskMtime: null,
   isDiskVersionInSyncWithBaseline: true,
+  hasEverBeenSaved: false,
 };
 
 /**
@@ -26,15 +28,19 @@ export const useDocumentStore = create<DocumentStore>((set) => ({
   currentCanonicalMarkdown: "",
   isDirty: false,
   currentFilePath: null,
+  isUntitled: false,
+  hasActiveDocument: false,
 
   setFilePath: (path) =>
     set((state) => ({
       currentFilePath: path,
       activeDocument: {
         ...state.activeDocument,
+        kind: path ? "file" : state.activeDocument.kind,
         path,
         name: path ? basename(path) : null,
         lastKnownPath: path,
+        hasEverBeenSaved: Boolean(path) || state.activeDocument.hasEverBeenSaved,
       },
     })),
   markLoaded: ({ rawMarkdown, canonicalMarkdown, path, fileMtime, source }) =>
@@ -42,7 +48,10 @@ export const useDocumentStore = create<DocumentStore>((set) => ({
       currentCanonicalMarkdown: canonicalMarkdown,
       currentFilePath: path,
       isDirty: false,
+      isUntitled: false,
+      hasActiveDocument: true,
       activeDocument: {
+        kind: "file",
         path,
         name: path ? basename(path) : null,
         rawLoadedContent: rawMarkdown,
@@ -56,6 +65,7 @@ export const useDocumentStore = create<DocumentStore>((set) => ({
           source === "reload" ? new Date().toISOString() : null,
         lastObservedDiskMtime: fileMtime,
         isDiskVersionInSyncWithBaseline: true,
+        hasEverBeenSaved: true,
       },
     })),
   markSaved: ({ canonicalMarkdown, path, fileMtime }) =>
@@ -63,8 +73,11 @@ export const useDocumentStore = create<DocumentStore>((set) => ({
       currentCanonicalMarkdown: canonicalMarkdown,
       currentFilePath: path,
       isDirty: false,
+      isUntitled: !path,
+      hasActiveDocument: true,
       activeDocument: {
         ...state.activeDocument,
+        kind: path ? "file" : "untitled",
         path,
         name: path ? basename(path) : null,
         lastSavedCanonicalContent: canonicalMarkdown,
@@ -75,6 +88,7 @@ export const useDocumentStore = create<DocumentStore>((set) => ({
         externalChangeDetectedAt: null,
         lastObservedDiskMtime: fileMtime,
         isDiskVersionInSyncWithBaseline: true,
+        hasEverBeenSaved: Boolean(path) || state.activeDocument.hasEverBeenSaved,
       },
     })),
   reconcileCurrentCanonicalMarkdown: (markdown) =>
@@ -112,6 +126,30 @@ export const useDocumentStore = create<DocumentStore>((set) => ({
         hasExternalChangeWarning: false,
         externalChangeDetectedAt: null,
         isDiskVersionInSyncWithBaseline: true,
+      },
+    })),
+  markNewUntitled: ({ canonicalMarkdown }) =>
+    set((state) => ({
+      currentCanonicalMarkdown: canonicalMarkdown,
+      currentFilePath: null,
+      isDirty: false,
+      isUntitled: true,
+      hasActiveDocument: true,
+      activeDocument: {
+        ...state.activeDocument,
+        kind: "untitled",
+        path: null,
+        name: null,
+        rawLoadedContent: "",
+        lastSavedCanonicalContent: canonicalMarkdown,
+        lastSavedAt: null,
+        fileMtime: null,
+        hasExternalChangeWarning: false,
+        externalChangeDetectedAt: null,
+        lastReloadedAt: null,
+        lastObservedDiskMtime: null,
+        isDiskVersionInSyncWithBaseline: true,
+        hasEverBeenSaved: false,
       },
     })),
 }));

--- a/src/styles.css
+++ b/src/styles.css
@@ -140,6 +140,63 @@ body {
   background: var(--color-bg);
 }
 
+.empty-state-shell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px;
+}
+
+.empty-state-panel {
+  width: min(520px, 100%);
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  padding: 24px;
+  background: #fff;
+}
+
+.empty-state-panel h1 {
+  font-size: 24px;
+  margin-bottom: 8px;
+}
+
+.empty-state-panel p {
+  color: #666;
+  margin-bottom: 16px;
+}
+
+.empty-state-actions {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.empty-state-actions button,
+.empty-state-recent-item {
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: #fff;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+
+.empty-state-actions button:hover,
+.empty-state-recent-item:hover {
+  background: var(--color-btn-hover);
+}
+
+.empty-state-recent-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.empty-state-recent-item {
+  width: 100%;
+  text-align: left;
+}
+
 .editor-content {
   max-width: 780px;
   margin: 0 auto;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,6 +8,8 @@ export interface FileMetadata {
 
 /** Metadata carried with the currently active document. */
 export interface ActiveDocument {
+  /** Current document mode in the single-pane workflow. */
+  kind: "none" | "untitled" | "file";
   /** Absolute path on disk; null for untitled documents. */
   path: string | null;
   /** Basename derived from path, or null for untitled documents. */
@@ -32,6 +34,8 @@ export interface ActiveDocument {
   lastObservedDiskMtime: number | null;
   /** True when current saved baseline is aligned with last known disk version. */
   isDiskVersionInSyncWithBaseline: boolean;
+  /** True after the current document has ever been saved/opened from disk. */
+  hasEverBeenSaved: boolean;
 }
 
 /** State shape managed by the document Zustand store. */
@@ -44,6 +48,10 @@ export interface DocumentState {
   isDirty: boolean;
   /** Absolute path of the file currently open; null if not yet saved. */
   currentFilePath: string | null;
+  /** True when editor currently points to an unsaved untitled document. */
+  isUntitled: boolean;
+  /** True when there is a document shown in editor (file or untitled). */
+  hasActiveDocument: boolean;
 }
 
 /** Mutating actions exposed by the document store. */
@@ -73,6 +81,10 @@ export interface DocumentActions {
   }) => void;
   /** Clear external change warning (e.g. after open/save). */
   clearExternalChangeWarning: () => void;
+  /** Start a new untitled document baseline. */
+  markNewUntitled: (payload: {
+    canonicalMarkdown: string;
+  }) => void;
 }
 
 export interface OpenDocumentResult {


### PR DESCRIPTION
### Motivation
- Provide a first-class, safe workflow for a single unsaved document ("Untitled") so the app is usable without opening an existing file. 
- Keep file/document orchestration centralized (same layer for New/Open/Save/Save As/Reload) and preserve the existing canonical markdown lifecycle and dirty logic. 
- Offer a minimal, non-distracting empty/start state when no document is active.

### Description
- Add a centralized `New` action: implemented `runNewAction` in `src/features/documents/fileActionService.ts` and hooked it into toolbar, native menu (`File → New`) and the `Cmd/Ctrl+N` shortcut so all entry-points share the same confirm/discard flow.
- Introduce explicit untitled/document state in store/types: added `activeDocument.kind`, `isUntitled`, `hasActiveDocument`, `hasEverBeenSaved`, and `markNewUntitled` to `src/stores/documentStore.ts` and `src/types/index.ts` to represent the single-pane mode correctly and deterministically initialize untitled baselines.
- Implement untitled baseline creation: `createNewUntitledDocument()` in `src/features/documents/documentService.ts` sets a deterministic empty editor HTML (`"<p></p>"`) and canonical markdown (`"\n"`) and calls `markNewUntitled` on the store.
- Preserve Save semantics: `saveDocument()` still falls back to `saveDocumentAs()` when `currentFilePath` is `null`; on successful `Save As` the store is updated, recent files and `lastOpenedFilePath` are updated only for concrete paths.
- Add minimal empty/start state UI: `Editor` renders a compact empty state panel (New/Open + recent files) when `hasActiveDocument === false` and otherwise renders the normal editor; new CSS rules added to `src/styles.css`.
- Wire UI and UX pieces: toolbar gets a `New` button (`src/components/Toolbar.tsx`), `App.tsx` and editor controller expose and use `handleNew`, window title logic shows `Untitled - mdedit` / `*Untitled - mdedit` for untitled docs, and `Reload` is disabled when no `currentFilePath`.
- Files changed (high level):
  - `src/features/documents/fileActionService.ts` — `runNewAction` added and reuse of centralized actions.
  - `src/features/documents/documentService.ts` — untitled baseline constants and `createNewUntitledDocument()`.
  - `src/stores/documentStore.ts` — new fields and `markNewUntitled` implementation.
  - `src/types/index.ts` — types for `kind`, `isUntitled`, `hasActiveDocument`, `hasEverBeenSaved`, `markNewUntitled`.
  - `src/features/editor/useEditorController.ts` — added menu/shortcut/title handling and `handleNew` wiring.
  - `src/components/Toolbar.tsx` — `New` button.
  - `src/features/editor/Editor.tsx` — minimal empty state rendering.
  - `src/components/StatusBar.tsx` — shows `No document` vs `Untitled` and keeps saved/modified label.
  - `src/app/App.tsx` — passes new handlers/props into editor/toolbar.
  - `src/styles.css` — styles for empty state.

### Testing
- Attempted build: ran `npm run build` (TypeScript + Vite) and the compile step failed due to a project dependency issue: `Cannot find module 'remark-gfm' or its corresponding type declarations` in `src/services/markdownService.ts`, so full automated build did not complete (failure).
- TypeScript runtime/logic checks done during development: local TS error for `basename(path)` nullability was corrected; remaining blocking dependency is the missing `remark-gfm` package.  

Note: code changes are committed and ready for CI once the `remark-gfm` dependency is installed or types are made available; the functionality and flows are implemented and wired but require the project to successfully compile in CI to fully validate.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d582eda33483229b968cce9bfec949)