### PR TITLE
Add code block language selection and lightweight syntax highlighting

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -22,6 +22,9 @@ function AppContent() {
     handleInsertLink,
     handleRemoveLink,
     handleInsertImage,
+    activeCodeBlockLanguage,
+    handleToggleCodeBlock,
+    handleSetCodeBlockLanguage,
   } = useEditorController();
 
   return (
@@ -40,6 +43,9 @@ function AppContent() {
         onInsertImage={() => void handleInsertImage()}
         canReload={Boolean(currentFilePath)}
         highlightReload={activeDocument.hasExternalChangeWarning}
+        activeCodeBlockLanguage={activeCodeBlockLanguage}
+        onToggleCodeBlock={handleToggleCodeBlock}
+        onSetCodeBlockLanguage={handleSetCodeBlockLanguage}
       />
       <EditorArea
         editor={editor}

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -3,6 +3,7 @@
  */
 import type { Editor } from "@tiptap/react";
 
+import { SUPPORTED_CODE_BLOCK_LANGUAGES } from "../features/editor/codeBlockSyntax";
 import { insertDefaultTable, insertTaskList } from "../features/editor/editorCommands";
 import { basename } from "../lib/utils";
 
@@ -20,6 +21,9 @@ interface ToolbarProps {
   onInsertImage: () => void;
   canReload: boolean;
   highlightReload: boolean;
+  activeCodeBlockLanguage: string | null;
+  onToggleCodeBlock: () => void;
+  onSetCodeBlockLanguage: (language: string) => void;
 }
 
 export default function Toolbar({
@@ -36,7 +40,13 @@ export default function Toolbar({
   onInsertImage,
   canReload,
   highlightReload,
+  activeCodeBlockLanguage,
+  onToggleCodeBlock,
+  onSetCodeBlockLanguage,
 }: ToolbarProps) {
+  const isCodeBlockActive = Boolean(activeCodeBlockLanguage);
+  const languageLabel = activeCodeBlockLanguage ?? "plaintext";
+
   return (
     <div className="toolbar" role="toolbar" aria-label="Editor toolbar">
       <div className="toolbar-group">
@@ -159,13 +169,33 @@ export default function Toolbar({
         </button>
 
         <button
-          onClick={() => editor?.chain().focus().toggleCodeBlock().run()}
+          onClick={onToggleCodeBlock}
           className={editor?.isActive("codeBlock") ? "active" : ""}
           disabled={!editor}
           title="Code block"
         >
           {"</>"}
         </button>
+
+        <label className={`code-language-control ${isCodeBlockActive ? "active" : ""}`}>
+          <span>Code:</span>
+          <select
+            value={languageLabel}
+            onChange={(event) => onSetCodeBlockLanguage(event.target.value)}
+            disabled={!editor || !isCodeBlockActive}
+            title={
+              isCodeBlockActive
+                ? "Set active code block language"
+                : "Place caret inside a code block to change language"
+            }
+          >
+            {SUPPORTED_CODE_BLOCK_LANGUAGES.map((language) => (
+              <option key={language} value={language}>
+                {language}
+              </option>
+            ))}
+          </select>
+        </label>
 
         <button
           onClick={onInsertLink}

--- a/src/features/editor/codeBlockSyntax.ts
+++ b/src/features/editor/codeBlockSyntax.ts
@@ -1,0 +1,292 @@
+import CodeBlock from "@tiptap/extension-code-block";
+import { Plugin } from "@tiptap/pm/state";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+
+export const SUPPORTED_CODE_BLOCK_LANGUAGES = [
+  "plaintext",
+  "javascript",
+  "typescript",
+  "json",
+  "html",
+  "css",
+  "bash",
+  "sql",
+  "yaml",
+  "markdown",
+] as const;
+
+export type SupportedCodeBlockLanguage = (typeof SUPPORTED_CODE_BLOCK_LANGUAGES)[number];
+
+const LANGUAGE_ALIASES: Record<string, SupportedCodeBlockLanguage> = {
+  text: "plaintext",
+  plain: "plaintext",
+  plaintext: "plaintext",
+  js: "javascript",
+  javascript: "javascript",
+  ts: "typescript",
+  typescript: "typescript",
+  json: "json",
+  html: "html",
+  xml: "html",
+  css: "css",
+  sh: "bash",
+  shell: "bash",
+  bash: "bash",
+  zsh: "bash",
+  sql: "sql",
+  yml: "yaml",
+  yaml: "yaml",
+  md: "markdown",
+  markdown: "markdown",
+};
+
+const KEYWORDS: Record<string, string[]> = {
+  javascript: [
+    "const",
+    "let",
+    "var",
+    "function",
+    "return",
+    "if",
+    "else",
+    "for",
+    "while",
+    "switch",
+    "case",
+    "break",
+    "class",
+    "new",
+    "import",
+    "export",
+    "from",
+    "async",
+    "await",
+    "try",
+    "catch",
+    "throw",
+    "null",
+    "undefined",
+    "true",
+    "false",
+  ],
+  typescript: [
+    "interface",
+    "type",
+    "implements",
+    "extends",
+    "enum",
+    "readonly",
+    "public",
+    "private",
+    "protected",
+    "declare",
+    "as",
+    "unknown",
+    "never",
+    ...[
+      "const",
+      "let",
+      "var",
+      "function",
+      "return",
+      "if",
+      "else",
+      "for",
+      "while",
+      "class",
+      "import",
+      "export",
+      "from",
+      "async",
+      "await",
+      "true",
+      "false",
+      "null",
+    ],
+  ],
+  sql: [
+    "select",
+    "from",
+    "where",
+    "insert",
+    "into",
+    "update",
+    "delete",
+    "join",
+    "left",
+    "right",
+    "inner",
+    "outer",
+    "group",
+    "by",
+    "order",
+    "limit",
+    "having",
+    "as",
+    "and",
+    "or",
+    "not",
+    "null",
+    "create",
+    "table",
+  ],
+  bash: [
+    "if",
+    "then",
+    "fi",
+    "for",
+    "in",
+    "do",
+    "done",
+    "case",
+    "esac",
+    "function",
+    "export",
+    "local",
+    "echo",
+    "cat",
+    "grep",
+    "awk",
+    "sed",
+  ],
+};
+
+function keywordRegex(language: "javascript" | "typescript" | "sql" | "bash"): RegExp {
+  const body = KEYWORDS[language].join("|");
+  const flags = language === "sql" ? "gi" : "g";
+  return new RegExp(`\\b(${body})\\b`, flags);
+}
+
+function addMatches(
+  decorations: Decoration[],
+  text: string,
+  regex: RegExp,
+  className: string,
+  offset: number
+): void {
+  for (const match of text.matchAll(regex)) {
+    const index = match.index;
+    const value = match[0];
+    if (index === undefined || !value) continue;
+    decorations.push(
+      Decoration.inline(offset + index, offset + index + value.length, {
+        class: className,
+      })
+    );
+  }
+}
+
+function highlightCode(language: string | null | undefined, text: string, offset: number): Decoration[] {
+  const normalized = normalizeCodeBlockLanguage(language);
+  const decorations: Decoration[] = [];
+
+  if (normalized === "plaintext") {
+    return decorations;
+  }
+
+  if (normalized === "javascript" || normalized === "typescript") {
+    addMatches(decorations, text, /\/\/.*$/gm, "cm-comment", offset);
+    addMatches(decorations, text, /\/\*[\s\S]*?\*\//g, "cm-comment", offset);
+    addMatches(decorations, text, /(["'`])(?:\\.|(?!\1)[\s\S])*\1/g, "cm-string", offset);
+    addMatches(decorations, text, /\b\d+(?:\.\d+)?\b/g, "cm-number", offset);
+    addMatches(
+      decorations,
+      text,
+      keywordRegex(normalized === "typescript" ? "typescript" : "javascript"),
+      "cm-keyword",
+      offset
+    );
+    return decorations;
+  }
+
+  if (normalized === "json") {
+    addMatches(decorations, text, /"(?:\\.|[^"\\])*"(?=\s*:)/g, "cm-property", offset);
+    addMatches(decorations, text, /"(?:\\.|[^"\\])*"/g, "cm-string", offset);
+    addMatches(decorations, text, /\b-?\d+(?:\.\d+)?(?:e[+-]?\d+)?\b/gi, "cm-number", offset);
+    addMatches(decorations, text, /\b(true|false|null)\b/g, "cm-keyword", offset);
+    return decorations;
+  }
+
+  if (normalized === "html") {
+    addMatches(decorations, text, /<\/?[a-zA-Z][\w:-]*/g, "cm-keyword", offset);
+    addMatches(decorations, text, /\s[\w:-]+(?==)/g, "cm-property", offset);
+    addMatches(decorations, text, /"(?:\\.|[^"\\])*"/g, "cm-string", offset);
+    return decorations;
+  }
+
+  if (normalized === "css") {
+    addMatches(decorations, text, /\/\*[\s\S]*?\*\//g, "cm-comment", offset);
+    addMatches(decorations, text, /(^|[;{]\s*)([.#]?[a-zA-Z_-][\w-]*)/gm, "cm-keyword", offset);
+    addMatches(decorations, text, /([a-zA-Z-]+)(?=\s*:)/g, "cm-property", offset);
+    addMatches(decorations, text, /#[0-9a-fA-F]{3,8}\b/g, "cm-number", offset);
+    return decorations;
+  }
+
+  if (normalized === "bash") {
+    addMatches(decorations, text, /(^|\s)#[^\n]*/g, "cm-comment", offset);
+    addMatches(decorations, text, /\$[{(]?[A-Za-z_][\w]*[)}]?/g, "cm-variable", offset);
+    addMatches(decorations, text, /(["'])(?:\\.|(?!\1)[\s\S])*\1/g, "cm-string", offset);
+    addMatches(decorations, text, keywordRegex("bash"), "cm-keyword", offset);
+    return decorations;
+  }
+
+  if (normalized === "sql") {
+    addMatches(decorations, text, /--.*$/gm, "cm-comment", offset);
+    addMatches(decorations, text, /(["'])(?:\\.|(?!\1)[\s\S])*\1/g, "cm-string", offset);
+    addMatches(decorations, text, /\b\d+(?:\.\d+)?\b/g, "cm-number", offset);
+    addMatches(decorations, text, keywordRegex("sql"), "cm-keyword", offset);
+    return decorations;
+  }
+
+  if (normalized === "yaml") {
+    addMatches(decorations, text, /(^|\s)#[^\n]*/g, "cm-comment", offset);
+    addMatches(decorations, text, /^[ \t-]*[A-Za-z0-9_.-]+(?=\s*:)/gm, "cm-property", offset);
+    addMatches(decorations, text, /(["'])(?:\\.|(?!\1)[\s\S])*\1/g, "cm-string", offset);
+    addMatches(decorations, text, /\b(true|false|null|yes|no|on|off)\b/gi, "cm-keyword", offset);
+    return decorations;
+  }
+
+  if (normalized === "markdown") {
+    addMatches(decorations, text, /^#{1,6}\s.*$/gm, "cm-keyword", offset);
+    addMatches(decorations, text, /`[^`\n]+`/g, "cm-string", offset);
+    addMatches(decorations, text, /\[([^\]]+)\]\(([^)]+)\)/g, "cm-property", offset);
+    addMatches(decorations, text, /^\s*[-*+]\s+/gm, "cm-variable", offset);
+  }
+
+  return decorations;
+}
+
+export function normalizeCodeBlockLanguage(language: string | null | undefined): SupportedCodeBlockLanguage {
+  if (!language) return "plaintext";
+  const normalized = LANGUAGE_ALIASES[language.trim().toLowerCase()];
+  return normalized ?? "plaintext";
+}
+
+export const CodeBlockWithSyntax = CodeBlock.extend({
+  addOptions() {
+    return {
+      ...this.parent?.(),
+      defaultLanguage: "plaintext",
+    };
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      ...(this.parent?.() ?? []),
+      new Plugin({
+        props: {
+          decorations: (state) => {
+            const decorations: Decoration[] = [];
+            state.doc.descendants((node, pos) => {
+              if (node.type.name !== this.name) return;
+              const text = node.textContent;
+              if (!text) return;
+              decorations.push(...highlightCode(node.attrs.language, text, pos + 1));
+            });
+            return DecorationSet.create(state.doc, decorations);
+          },
+        },
+      }),
+    ];
+  },
+});

--- a/src/features/editor/editorCommands.ts
+++ b/src/features/editor/editorCommands.ts
@@ -1,6 +1,7 @@
 import type { Editor } from "@tiptap/react";
 
 import type { InputDialogOptions } from "../ux/useAppUx";
+import { normalizeCodeBlockLanguage } from "./codeBlockSyntax";
 
 type RequestInput = (options: InputDialogOptions) => Promise<string | null>;
 
@@ -118,6 +119,27 @@ export function insertTaskList(editor: Editor): void {
       ],
     })
     .run();
+}
+
+export function toggleCodeBlock(editor: Editor): void {
+  if (editor.isActive("codeBlock")) {
+    editor.chain().focus().toggleCodeBlock().run();
+    return;
+  }
+
+  editor.chain().focus().setCodeBlock({ language: "plaintext" }).run();
+}
+
+export function getActiveCodeBlockLanguage(editor: Editor): string | null {
+  if (!editor.isActive("codeBlock")) return null;
+  const language = editor.getAttributes("codeBlock").language as string | null | undefined;
+  return normalizeCodeBlockLanguage(language);
+}
+
+export function setCodeBlockLanguage(editor: Editor, language: string): void {
+  if (!editor.isActive("codeBlock")) return;
+  const nextLanguage = normalizeCodeBlockLanguage(language);
+  editor.chain().focus().updateAttributes("codeBlock", { language: nextLanguage }).run();
 }
 
 export function insertDefaultTable(editor: Editor): void {

--- a/src/features/editor/editorExtensions.ts
+++ b/src/features/editor/editorExtensions.ts
@@ -1,5 +1,8 @@
 import { Mark, Node, mergeAttributes } from "@tiptap/core";
 import { tableEditing } from "@tiptap/pm/tables";
+import { CodeBlockWithSyntax } from "./codeBlockSyntax";
+
+export { CodeBlockWithSyntax };
 
 export const LinkMark = Mark.create({
   name: "link",

--- a/src/features/editor/useEditorController.ts
+++ b/src/features/editor/useEditorController.ts
@@ -4,6 +4,7 @@ import StarterKit from "@tiptap/starter-kit";
 import { Menu, Submenu, PredefinedMenuItem } from "@tauri-apps/api/menu";
 
 import {
+  CodeBlockWithSyntax,
   ImageNode,
   LinkMark,
   TableCellNode,
@@ -30,7 +31,14 @@ import {
   createDiscardChangesConfirmOptions,
 } from "../documents/fileActionService";
 import { reconcileCanonicalFromEditorHtml } from "../documents/documentService";
-import { insertImage, insertLink, removeLink } from "./editorCommands";
+import {
+  getActiveCodeBlockLanguage,
+  insertImage,
+  insertLink,
+  removeLink,
+  setCodeBlockLanguage,
+  toggleCodeBlock,
+} from "./editorCommands";
 
 const APP_NAME = "mdedit";
 const RELOAD_ACCELERATOR = "CmdOrCtrl+Alt+R";
@@ -63,6 +71,9 @@ export interface EditorController {
   handleInsertLink: () => Promise<void>;
   handleRemoveLink: () => void;
   handleInsertImage: () => Promise<void>;
+  activeCodeBlockLanguage: string | null;
+  handleToggleCodeBlock: () => void;
+  handleSetCodeBlockLanguage: (language: string) => void;
 }
 
 export function useEditorController(): EditorController {
@@ -72,13 +83,17 @@ export function useEditorController(): EditorController {
   const reconcileRunIdRef = useRef(0);
   const startupReopenDoneRef = useRef(false);
   const [persistedState, setPersistedState] = useState(getInitialPersistedState);
+  const [activeCodeBlockLanguage, setActiveCodeBlockLanguage] = useState<string | null>(null);
   const { isDirty, currentFilePath, isUntitled, hasActiveDocument } =
     useDocumentStore();
   const { confirm, notify, requestInput } = useAppUx();
 
   const editor = useEditor({
     extensions: [
-      StarterKit,
+      StarterKit.configure({
+        codeBlock: false,
+      }),
+      CodeBlockWithSyntax,
       LinkMark,
       ImageNode,
       TaskListNode,
@@ -168,6 +183,41 @@ export function useEditorController(): EditorController {
     if (!editor) return;
     await insertImage(editor, requestInput);
   }, [editor, requestInput]);
+
+  const handleToggleCodeBlock = useCallback(() => {
+    if (!editor) return;
+    toggleCodeBlock(editor);
+    setActiveCodeBlockLanguage(getActiveCodeBlockLanguage(editor));
+  }, [editor]);
+
+  const handleSetCodeBlockLanguage = useCallback(
+    (language: string) => {
+      if (!editor) return;
+      setCodeBlockLanguage(editor, language);
+      setActiveCodeBlockLanguage(getActiveCodeBlockLanguage(editor));
+    },
+    [editor]
+  );
+
+  useEffect(() => {
+    if (!editor) {
+      setActiveCodeBlockLanguage(null);
+      return;
+    }
+
+    const syncLanguage = () => {
+      setActiveCodeBlockLanguage(getActiveCodeBlockLanguage(editor));
+    };
+
+    syncLanguage();
+    editor.on("selectionUpdate", syncLanguage);
+    editor.on("transaction", syncLanguage);
+
+    return () => {
+      editor.off("selectionUpdate", syncLanguage);
+      editor.off("transaction", syncLanguage);
+    };
+  }, [editor]);
 
   useEffect(() => {
     if (!editor || startupReopenDoneRef.current) return;
@@ -435,6 +485,9 @@ export function useEditorController(): EditorController {
       handleInsertLink,
       handleRemoveLink,
       handleInsertImage,
+      activeCodeBlockLanguage,
+      handleToggleCodeBlock,
+      handleSetCodeBlockLanguage,
     }),
     [
       editor,
@@ -447,6 +500,9 @@ export function useEditorController(): EditorController {
       handleInsertLink,
       handleRemoveLink,
       handleInsertImage,
+      activeCodeBlockLanguage,
+      handleToggleCodeBlock,
+      handleSetCodeBlockLanguage,
       hasActiveDocument,
       persistedState.recentFiles,
     ]

--- a/src/services/markdownService.ts
+++ b/src/services/markdownService.ts
@@ -55,15 +55,57 @@ export async function serializeEditorToMarkdown(
  */
 export function normalizeMarkdown(markdown: string): string {
   const withLf = markdown.replace(/\r\n?/g, "\n");
-  const trimmedTrailingWhitespace = withLf
-    .split("\n")
-    .map((line) => line.replace(/[\t ]+$/g, ""))
-    .join("\n");
-  const collapsedBlankRuns = trimmedTrailingWhitespace.replace(/\n{3,}/g, "\n\n");
-  const normalizedTaskMarkers = collapsedBlankRuns.replace(/\[(X)\]/g, "[x]");
-  const withoutTrailingNewlines = normalizedTaskMarkers.replace(/\n+$/g, "");
+  const lines = withLf.split("\n");
+  const normalized: string[] = [];
+  let inCodeFence = false;
+  let currentFence: "```" | "~~~" | null = null;
+  let pendingBlankLinesOutsideFence = 0;
 
-  return `${withoutTrailingNewlines}\n`;
+  const flushPendingBlankLines = () => {
+    if (pendingBlankLinesOutsideFence > 0) {
+      normalized.push("");
+      pendingBlankLinesOutsideFence = 0;
+    }
+  };
+
+  const toggleFenceState = (line: string): void => {
+    const marker = line.startsWith("```") ? "```" : line.startsWith("~~~") ? "~~~" : null;
+    if (!marker) return;
+
+    if (!inCodeFence) {
+      inCodeFence = true;
+      currentFence = marker;
+      return;
+    }
+
+    if (currentFence === marker) {
+      inCodeFence = false;
+      currentFence = null;
+    }
+  };
+
+  for (const line of lines) {
+    if (inCodeFence) {
+      normalized.push(line);
+      toggleFenceState(line);
+      continue;
+    }
+
+    const trimmed = line.replace(/[\t ]+$/g, "");
+    const normalizedTaskMarker = trimmed.replace(/\[(X)\]/g, "[x]");
+
+    if (!normalizedTaskMarker) {
+      pendingBlankLinesOutsideFence += 1;
+      continue;
+    }
+
+    flushPendingBlankLines();
+    normalized.push(normalizedTaskMarker);
+    toggleFenceState(normalizedTaskMarker);
+  }
+
+  const withoutTrailingBlankLines = normalized.join("\n").replace(/\n+$/g, "");
+  return `${withoutTrailingBlankLines}\n`;
 }
 
 async function markdownToHtml(markdown: string): Promise<string> {

--- a/src/styles.css
+++ b/src/styles.css
@@ -129,6 +129,33 @@ body {
   color: var(--color-text);
 }
 
+.code-language-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: 2px;
+  padding: 0 4px;
+  color: var(--color-text-muted);
+  font-size: 12px;
+}
+
+.code-language-control.active {
+  color: var(--color-text);
+}
+
+.code-language-control select {
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  background: #fff;
+  font-size: 12px;
+  padding: 3px 5px;
+  color: var(--color-text);
+}
+
+.code-language-control select:disabled {
+  opacity: 0.6;
+}
+
 
 /* ============================================================
    Editor area
@@ -285,6 +312,30 @@ body {
   background: transparent;
   padding: 0;
   font-size: inherit;
+}
+
+.ProseMirror pre .cm-comment {
+  color: #6a737d;
+}
+
+.ProseMirror pre .cm-keyword {
+  color: #8a3ffc;
+}
+
+.ProseMirror pre .cm-string {
+  color: #0f7b0f;
+}
+
+.ProseMirror pre .cm-number {
+  color: #b35a00;
+}
+
+.ProseMirror pre .cm-property {
+  color: #005a9c;
+}
+
+.ProseMirror pre .cm-variable {
+  color: #7a2f8f;
 }
 
 .ProseMirror hr {


### PR DESCRIPTION
### Motivation
- Improve technical markdown authoring by adding syntax highlighting for fenced code blocks and a simple language selection workflow.  
- Preserve the current single-pane Typora-like UX and avoid adding a heavy embedded editor or IDE features.  
- Ensure fenced code language info is round-tripped into canonical Markdown (fence info retained) and normalisation doesn't corrupt code block interiors.  
- Provide deterministic, small-surface changes confined to editor extensions, commands, controller and markdown pipeline.

### Description
- Added a new extension `CodeBlockWithSyntax` that extends Tiptap `codeBlock`, provides a `defaultLanguage` of `plaintext`, and applies lightweight decoration-based syntax tokenization for common languages; file: `src/features/editor/codeBlockSyntax.ts`.  
- Implemented language normalization/aliases and helpers `normalizeCodeBlockLanguage`, `getActiveCodeBlockLanguage`, `setCodeBlockLanguage`, and `toggleCodeBlock` in `src/features/editor/editorCommands.ts`.  
- Wired the extension into the editor controller by disabling `StarterKit`'s built-in `codeBlock`, registering `CodeBlockWithSyntax`, and adding state + handlers to track and set the active code block language; file: `src/features/editor/useEditorController.ts`.  
- Added a compact `Code:` select to the toolbar that becomes active when the caret is inside a code block and allows changing the block language, plus minimal styling for token classes and the control; files: `src/components/Toolbar.tsx`, `src/styles.css`.  
- Hardened markdown normalisation so trimming/collapsing of blank lines and task marker normalization only run outside fenced code blocks, improving fenced-block stability during the HTML↔Markdown canonical roundtrip; file: `src/services/markdownService.ts`.  
- Exported the new extension via `src/features/editor/editorExtensions.ts` and made small wiring changes in `src/app/App.tsx` to pass new props to the toolbar.

### Testing
- Attempted a TypeScript + Vite build with `npm run build`; in this environment the build failed due to dependency resolution/type import issues for `remark-gfm` (environment/node_modules state), so the failure is environmental and not caused by the new code.  
- No automated unit tests were added in this iteration; manual verification performed by running the app locally is recommended once dependencies are healthy and `npm install` completes successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d586a8874883228b5849d1e4687ddd)