### PR TITLE
Add toggleable heading outline sidebar

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -27,6 +27,8 @@ function AppContent() {
     activeCodeBlockLanguage,
     handleToggleCodeBlock,
     handleSetCodeBlockLanguage,
+    isOutlineVisible,
+    handleToggleOutline,
   } = useEditorController();
 
   return (
@@ -50,6 +52,8 @@ function AppContent() {
         activeCodeBlockLanguage={activeCodeBlockLanguage}
         onToggleCodeBlock={handleToggleCodeBlock}
         onSetCodeBlockLanguage={handleSetCodeBlockLanguage}
+        isOutlineVisible={isOutlineVisible}
+        onToggleOutline={handleToggleOutline}
       />
       <EditorArea
         editor={editor}
@@ -58,6 +62,7 @@ function AppContent() {
         onNew={() => void handleNew()}
         onOpen={() => void handleOpen()}
         onOpenRecent={(path) => void handleOpenRecent(path)}
+        isOutlineVisible={isOutlineVisible}
       />
       <StatusBar
         isDirty={isDirty}

--- a/src/components/OutlineSidebar.tsx
+++ b/src/components/OutlineSidebar.tsx
@@ -1,0 +1,41 @@
+import type { OutlineHeading } from "../features/editor/outline";
+
+interface OutlineSidebarProps {
+  headings: OutlineHeading[];
+  activeHeadingId: string | null;
+  onSelectHeading: (heading: OutlineHeading) => void;
+}
+
+export default function OutlineSidebar({
+  headings,
+  activeHeadingId,
+  onSelectHeading,
+}: OutlineSidebarProps) {
+  return (
+    <aside className="outline-sidebar" aria-label="Document outline">
+      <h2>Outline</h2>
+
+      {headings.length === 0 ? (
+        <p className="outline-empty">No headings yet</p>
+      ) : (
+        <ul className="outline-list">
+          {headings.map((heading) => (
+            <li key={heading.id}>
+              <button
+                type="button"
+                className={`outline-item ${
+                  heading.id === activeHeadingId ? "active" : ""
+                }`}
+                style={{ paddingLeft: `${12 + (heading.level - 1) * 14}px` }}
+                onClick={() => onSelectHeading(heading)}
+                title={heading.text}
+              >
+                {heading.text}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </aside>
+  );
+}

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -21,6 +21,7 @@ import {
   SaveAll,
   Table,
   Unlink,
+  PanelLeft,
 } from "lucide-react";
 
 import { SUPPORTED_CODE_BLOCK_LANGUAGES } from "../features/editor/codeBlockSyntax";
@@ -49,6 +50,8 @@ interface ToolbarProps {
   activeCodeBlockLanguage: string | null;
   onToggleCodeBlock: () => void;
   onSetCodeBlockLanguage: (language: string) => void;
+  isOutlineVisible: boolean;
+  onToggleOutline: () => void;
 }
 
 export default function Toolbar({
@@ -70,6 +73,8 @@ export default function Toolbar({
   activeCodeBlockLanguage,
   onToggleCodeBlock,
   onSetCodeBlockLanguage,
+  isOutlineVisible,
+  onToggleOutline,
 }: ToolbarProps) {
   const isCodeBlockActive = Boolean(activeCodeBlockLanguage);
   const languageLabel = activeCodeBlockLanguage ?? "plaintext";
@@ -249,6 +254,17 @@ export default function Toolbar({
           disabled={!editor}
           title="Insert image from URL"
           icon={<Image size={ICON_SIZE} strokeWidth={1.9} />}
+        />
+      </div>
+
+      <div className="toolbar-divider" aria-hidden />
+
+      <div className="toolbar-group" aria-label="View">
+        <IconButton
+          onClick={onToggleOutline}
+          active={isOutlineVisible}
+          title="Toggle outline"
+          icon={<PanelLeft size={ICON_SIZE} strokeWidth={1.9} />}
         />
       </div>
     </div>

--- a/src/features/editor/Editor.tsx
+++ b/src/features/editor/Editor.tsx
@@ -5,9 +5,18 @@
  * created in App so it can be shared with the Toolbar without prop-drilling
  * through extra wrapper components.
  */
+import { useCallback, useEffect, useRef, useState } from "react";
 import { FilePlus, FolderOpen, Sparkles } from "lucide-react";
 import { EditorContent, type Editor } from "@tiptap/react";
 import { basename } from "../../lib/utils";
+import OutlineSidebar from "../../components/OutlineSidebar";
+import {
+  areOutlineHeadingsEqual,
+  extractOutlineFromDoc,
+  getActiveHeadingId,
+  navigateToHeading,
+  type OutlineHeading,
+} from "./outline";
 
 interface EditorProps {
   editor: Editor | null;
@@ -16,6 +25,7 @@ interface EditorProps {
   onNew: () => void;
   onOpen: () => void;
   onOpenRecent: (path: string) => void;
+  isOutlineVisible: boolean;
 }
 
 export default function EditorArea({
@@ -25,7 +35,66 @@ export default function EditorArea({
   onNew,
   onOpen,
   onOpenRecent,
+  isOutlineVisible,
 }: EditorProps) {
+  const [outlineHeadings, setOutlineHeadings] = useState<OutlineHeading[]>([]);
+  const [activeHeadingId, setActiveHeadingId] = useState<string | null>(null);
+  const outlineRef = useRef<OutlineHeading[]>([]);
+
+  const updateOutline = useCallback(() => {
+    if (!editor) {
+      outlineRef.current = [];
+      setOutlineHeadings([]);
+      setActiveHeadingId(null);
+      return;
+    }
+
+    const nextOutline = extractOutlineFromDoc(editor.state.doc);
+    outlineRef.current = nextOutline;
+
+    setOutlineHeadings((previous) =>
+      areOutlineHeadingsEqual(previous, nextOutline) ? previous : nextOutline
+    );
+    setActiveHeadingId(getActiveHeadingId(nextOutline, editor.state.selection.from));
+  }, [editor]);
+
+  const updateActiveHeading = useCallback(() => {
+    if (!editor) {
+      setActiveHeadingId(null);
+      return;
+    }
+
+    setActiveHeadingId(
+      getActiveHeadingId(outlineRef.current, editor.state.selection.from)
+    );
+  }, [editor]);
+
+  useEffect(() => {
+    if (!editor) {
+      updateOutline();
+      return;
+    }
+
+    updateOutline();
+
+    editor.on("update", updateOutline);
+    editor.on("selectionUpdate", updateActiveHeading);
+
+    return () => {
+      editor.off("update", updateOutline);
+      editor.off("selectionUpdate", updateActiveHeading);
+    };
+  }, [editor, updateActiveHeading, updateOutline]);
+
+  const handleSelectHeading = useCallback(
+    (heading: OutlineHeading) => {
+      if (!editor) return;
+      navigateToHeading(editor, heading.pos);
+      setActiveHeadingId(heading.id);
+    },
+    [editor]
+  );
+
   if (showEmptyState) {
     return (
       <div className="editor-wrapper empty-state-shell">
@@ -66,8 +135,17 @@ export default function EditorArea({
   }
 
   return (
-    <div className="editor-wrapper">
-      <EditorContent editor={editor} className="editor-content" />
+    <div className="editor-main">
+      {isOutlineVisible ? (
+        <OutlineSidebar
+          headings={outlineHeadings}
+          activeHeadingId={activeHeadingId}
+          onSelectHeading={handleSelectHeading}
+        />
+      ) : null}
+      <div className="editor-wrapper">
+        <EditorContent editor={editor} className="editor-content" />
+      </div>
     </div>
   );
 }

--- a/src/features/editor/outline.ts
+++ b/src/features/editor/outline.ts
@@ -1,0 +1,83 @@
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import type { Editor } from "@tiptap/react";
+
+const UNTITLED_HEADING_FALLBACK = "Untitled heading";
+
+export interface OutlineHeading {
+  id: string;
+  text: string;
+  level: number;
+  pos: number;
+}
+
+export function extractOutlineFromDoc(doc: ProseMirrorNode): OutlineHeading[] {
+  const headings: OutlineHeading[] = [];
+
+  doc.descendants((node, pos) => {
+    if (node.type.name !== "heading") {
+      return true;
+    }
+
+    const levelAttr = node.attrs.level;
+    const level =
+      typeof levelAttr === "number" && levelAttr >= 1 && levelAttr <= 6 ? levelAttr : 1;
+    const text = node.textContent.trim() || UNTITLED_HEADING_FALLBACK;
+
+    headings.push({
+      id: `heading-${pos}`,
+      text,
+      level,
+      pos,
+    });
+
+    return false;
+  });
+
+  return headings;
+}
+
+export function getActiveHeadingId(
+  headings: OutlineHeading[],
+  selectionPos: number
+): string | null {
+  let activeId: string | null = null;
+
+  for (const heading of headings) {
+    if (heading.pos > selectionPos) {
+      break;
+    }
+    activeId = heading.id;
+  }
+
+  return activeId;
+}
+
+export function navigateToHeading(editor: Editor, pos: number): void {
+  const headingTextStart = Math.max(1, pos + 1);
+  editor.chain().focus().setTextSelection(headingTextStart).scrollIntoView().run();
+}
+
+export function areOutlineHeadingsEqual(
+  left: OutlineHeading[],
+  right: OutlineHeading[]
+): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  for (let index = 0; index < left.length; index += 1) {
+    const lhs = left[index];
+    const rhs = right[index];
+
+    if (
+      lhs.id !== rhs.id ||
+      lhs.text !== rhs.text ||
+      lhs.level !== rhs.level ||
+      lhs.pos !== rhs.pos
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/src/features/editor/useEditorController.ts
+++ b/src/features/editor/useEditorController.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useEditor, type Editor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
-import { Menu, Submenu, PredefinedMenuItem } from "@tauri-apps/api/menu";
+import { CheckMenuItem, Menu, PredefinedMenuItem, Submenu } from "@tauri-apps/api/menu";
 
 import {
   CodeBlockWithSyntax,
@@ -16,6 +16,7 @@ import {
 } from "./editorExtensions";
 
 import { basename } from "../../lib/utils";
+import { saveAppState } from "../../services/appStateService";
 import * as bridge from "../../services/tauriBridge";
 import { useAppUx } from "../ux/useAppUx";
 import { useDocumentStore } from "../../stores/documentStore";
@@ -78,6 +79,8 @@ export interface EditorController {
   activeCodeBlockLanguage: string | null;
   handleToggleCodeBlock: () => void;
   handleSetCodeBlockLanguage: (language: string) => void;
+  isOutlineVisible: boolean;
+  handleToggleOutline: () => void;
 }
 
 export function useEditorController(): EditorController {
@@ -211,6 +214,20 @@ export function useEditorController(): EditorController {
     },
     [editor]
   );
+
+  const handleToggleOutline = useCallback(() => {
+    setPersistedState((current) => {
+      const nextState = {
+        ...current,
+        ui: {
+          ...current.ui,
+          isOutlineVisible: !current.ui.isOutlineVisible,
+        },
+      };
+      saveAppState(nextState);
+      return nextState;
+    });
+  }, []);
 
   useEffect(() => {
     if (!editor) {
@@ -352,8 +369,22 @@ export function useEditorController(): EditorController {
           ],
         });
 
+        const viewSubmenu = await Submenu.new({
+          text: "View",
+          items: [
+            await CheckMenuItem.new({
+              id: "view-toggle-outline",
+              text: "Toggle Outline",
+              checked: persistedState.ui.isOutlineVisible,
+              action: () => {
+                handleToggleOutline();
+              },
+            }),
+          ],
+        });
+
         const menu = await Menu.new({
-          items: [fileSubmenu, editSubmenu],
+          items: [fileSubmenu, editSubmenu, viewSubmenu],
         });
 
         if (!disposed) {
@@ -380,6 +411,8 @@ export function useEditorController(): EditorController {
     handleExportHtml,
     handleExportPdf,
     persistedState.recentFiles,
+    persistedState.ui.isOutlineVisible,
+    handleToggleOutline,
   ]);
 
   useEffect(() => {
@@ -516,6 +549,8 @@ export function useEditorController(): EditorController {
       activeCodeBlockLanguage,
       handleToggleCodeBlock,
       handleSetCodeBlockLanguage,
+      isOutlineVisible: persistedState.ui.isOutlineVisible,
+      handleToggleOutline,
     }),
     [
       editor,
@@ -533,8 +568,10 @@ export function useEditorController(): EditorController {
       activeCodeBlockLanguage,
       handleToggleCodeBlock,
       handleSetCodeBlockLanguage,
+      handleToggleOutline,
       hasActiveDocument,
       persistedState.recentFiles,
+      persistedState.ui.isOutlineVisible,
     ]
   );
 }

--- a/src/services/appStateService.ts
+++ b/src/services/appStateService.ts
@@ -2,10 +2,15 @@ export interface AppSettings {
   reopenLastFileOnStartup: boolean;
 }
 
+export interface AppUiState {
+  isOutlineVisible: boolean;
+}
+
 export interface PersistedAppState {
   recentFiles: string[];
   lastOpenedFilePath: string | null;
   settings: AppSettings;
+  ui: AppUiState;
 }
 
 const STORAGE_KEY = "mdedit.appState.v1";
@@ -16,6 +21,9 @@ const DEFAULT_STATE: PersistedAppState = {
   lastOpenedFilePath: null,
   settings: {
     reopenLastFileOnStartup: true,
+  },
+  ui: {
+    isOutlineVisible: true,
   },
 };
 
@@ -30,6 +38,7 @@ function normalizeState(candidate: unknown): PersistedAppState {
 
   const draft = candidate as Partial<PersistedAppState> & {
     settings?: Partial<AppSettings>;
+    ui?: Partial<AppUiState>;
   };
 
   return {
@@ -42,6 +51,10 @@ function normalizeState(candidate: unknown): PersistedAppState {
       reopenLastFileOnStartup:
         draft.settings?.reopenLastFileOnStartup ??
         DEFAULT_STATE.settings.reopenLastFileOnStartup,
+    },
+    ui: {
+      isOutlineVisible:
+        draft.ui?.isOutlineVisible ?? DEFAULT_STATE.ui.isOutlineVisible,
     },
   };
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -158,6 +158,69 @@ body {
    Editor area
    ============================================================ */
 
+
+.editor-main {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
+
+.outline-sidebar {
+  width: clamp(190px, 19vw, 280px);
+  border-right: 1px solid var(--color-border);
+  background: #fafafa;
+  padding: 10px 8px;
+  overflow-y: auto;
+  flex-shrink: 0;
+}
+
+.outline-sidebar h2 {
+  font-size: 12px;
+  font-weight: 600;
+  color: #6b7280;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin: 4px 8px 10px;
+}
+
+.outline-empty {
+  font-size: 13px;
+  color: var(--color-text-muted);
+  padding: 6px 8px;
+}
+
+.outline-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.outline-item {
+  width: 100%;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  text-align: left;
+  font-size: 13px;
+  color: var(--color-text);
+  padding: 6px 8px;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.outline-item:hover {
+  background: #f0f3f8;
+}
+
+.outline-item.active {
+  background: var(--color-btn-active-bg);
+  border-color: #d4e2f5;
+  color: #1f4d86;
+}
+
 .editor-wrapper {
   flex: 1;
   overflow-y: auto;


### PR DESCRIPTION
### Motivation
- Provide a lightweight, non-intrusive outline sidebar so users can quickly navigate long documents by headings without redesigning the app.
- Keep UI minimal and architecture clean: sidebar is a presentational component and outline extraction / navigation logic lives in a small helper module.

### Description
- Added `src/features/editor/outline.ts` with `extractOutlineFromDoc`, `getActiveHeadingId`, `navigateToHeading`, `areOutlineHeadingsEqual` and a fallback `Untitled heading` to build an outline from the current editor state (not from disk).
- Added presentational `OutlineSidebar` (`src/components/OutlineSidebar.tsx`) which renders heading hierarchy, shows `No headings yet` placeholder, calls an `onSelectHeading` handler, and highlights the active item.
- Wired the editor lifecycle in `src/features/editor/Editor.tsx` to compute the outline on `update` and active heading on `selectionUpdate`, and to call `navigateToHeading` on click; the editor layout shows the sidebar when `isOutlineVisible` is true and preserves the original empty-state panel for no-document mode.
- Exposed toggle and persistence in controller and UI by updating `useEditorController` (`src/features/editor/useEditorController.ts`) to add `isOutlineVisible` and `handleToggleOutline`, persisting the value to app state via `saveAppState`; added a `View → Toggle Outline` native menu check item and a toolbar toggle button in `src/components/Toolbar.tsx` and passed props through `src/app/App.tsx`.
- Persisted UI flag in `src/services/appStateService.ts` by adding `ui.isOutlineVisible` with normalization and a default of `true`, and added minimal sidebar styling in `src/styles.css`.
- Files changed/added: `src/features/editor/outline.ts` (new), `src/components/OutlineSidebar.tsx` (new), `src/features/editor/Editor.tsx`, `src/features/editor/useEditorController.ts`, `src/components/Toolbar.tsx`, `src/app/App.tsx`, `src/services/appStateService.ts`, `src/styles.css`.

### Testing
- Attempted a production build with `npm run build`, but it failed in this environment due to inability to install external dependency `lucide-react` (npm registry returned 403), so a full build/type-check could not complete.
- No other automated tests were run in this environment; code compiles locally in-IDE edits (TS changes) but external dependency resolution is required to validate the final build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d66fd3f1d48322b318f3a2e11cae13)