### PR TITLE
Use application icon as favicon in web pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>mdedit</title>
+    <link rel="icon" type="image/png" href="/www/icon.png" />
+    <link rel="shortcut icon" type="image/png" href="/www/icon.png" />
   </head>
   <body>
     <div id="root"></div>

--- a/www/index.html
+++ b/www/index.html
@@ -4,7 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>mdedit – Markdown editor</title>
-  <link rel="icon" href="icon.png">
+  <link rel="icon" type="image/png" href="icon.png">
+  <link rel="shortcut icon" type="image/png" href="icon.png">
+  <link rel="apple-touch-icon" href="icon.png">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>


### PR DESCRIPTION
### Motivation
- Replace the default blue square tab icon with the application icon and expose the same image as favicon/shortcut/apple-touch-icon for the static web pages.

### Description
- Add `link rel="icon"` and `link rel="shortcut icon"` referencing `/www/icon.png` to the root `index.html` used by the app shell.
- Update `www/index.html` to explicitly set `type="image/png"` for the icon and add `rel="shortcut icon"` and `rel="apple-touch-icon"` pointing to `icon.png` in `/www`.
- Changes were committed with the message `Add app icon favicon links for web pages`.

### Testing
- Ran `git diff -- www/index.html index.html` to confirm the expected changes and it succeeded.
- Ran `git add index.html www/index.html && git commit -m "Add app icon favicon links for web pages"` and the commit succeeded.
- Verified file contents using `nl -ba index.html | sed -n '1,40p'; nl -ba www/index.html | sed -n '1,30p'` which showed the new link tags and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4ab594b708322b0174b9814067f2b)