### PR TITLE
Fix PDF rendering hangs and font resolution issues

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,6 +5,7 @@
   "permissions": [
     "core:default",
     "core:window:allow-destroy",
+    "core:window:allow-set-title",
     "allow-open-file-dialog",
     "allow-read-text-file",
     "allow-save-text-file",

--- a/src/services/pdfRenderer.ts
+++ b/src/services/pdfRenderer.ts
@@ -41,7 +41,7 @@ interface RenderContext {
 const ROBOTO_VFS_INSTALLED = installVfs();
 
 function installVfs(): boolean {
-  const target = pdfMake as { vfs?: unknown };
+  const target = pdfMake as { vfs?: unknown; fonts?: unknown };
   // vfs_fonts is exported either as the raw vfs object (newer builds) or
   // wrapped under `pdfMake.vfs` (older builds). Handle both.
   const candidate = (vfsFonts as { pdfMake?: { vfs?: unknown }; vfs?: unknown }) ?? {};
@@ -49,6 +49,17 @@ function installVfs(): boolean {
     (candidate as { pdfMake?: { vfs?: unknown } }).pdfMake?.vfs ??
     (candidate as { vfs?: unknown }).vfs ??
     vfsFonts;
+  // Without an explicit font map pdfmake's PDFKit pipeline silently fails
+  // resolving "Roboto" and `getBuffer` never fires its callback. Pin the
+  // four Roboto faces to the keys shipped in vfs_fonts.
+  target.fonts = {
+    Roboto: {
+      normal: "Roboto-Regular.ttf",
+      bold: "Roboto-Medium.ttf",
+      italics: "Roboto-Italic.ttf",
+      bolditalics: "Roboto-MediumItalic.ttf",
+    },
+  };
   return true;
 }
 
@@ -585,9 +596,24 @@ export async function renderEditorHtmlToPdfBytes(
 
   console.log('[DEBUG] PDF Renderer: Creating PDF');
   return new Promise<Uint8Array>((resolve, reject) => {
+    let settled = false;
+    // pdfmake's `getBuffer` is callback-based with no error channel: if the
+    // PDFKit pipeline throws asynchronously (typically a font/VFS resolution
+    // problem) the callback never fires and the export hangs silently. Guard
+    // with a timeout so the user sees a real error instead of nothing.
+    const timeout = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      console.error('[DEBUG] PDF Renderer: Timed out waiting for PDF buffer');
+      reject(new Error("PDF rendering timed out (no buffer produced within 15s)."));
+    }, 15_000);
+
     try {
       const generator = pdfMake.createPdf(docDefinition);
       generator.getBuffer((buffer: ArrayBuffer | Uint8Array) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
         console.log('[DEBUG] PDF Renderer: PDF buffer received');
         if (buffer instanceof Uint8Array) {
           resolve(buffer);
@@ -596,6 +622,9 @@ export async function renderEditorHtmlToPdfBytes(
         }
       });
     } catch (error) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
       console.error('[DEBUG] PDF Renderer: Error creating PDF:', error);
       reject(error);
     }


### PR DESCRIPTION
## Summary
This PR fixes silent hangs in PDF rendering by addressing font resolution failures and adding a timeout guard for the callback-based pdfmake API.

## Key Changes

- **Font Configuration**: Added explicit Roboto font mapping to pdfMake's font registry. Without this, pdfMake's PDFKit pipeline silently fails when resolving the "Roboto" font, causing `getBuffer` callbacks to never fire.

- **Timeout Protection**: Implemented a 15-second timeout guard around the PDF generation process. Since pdfmake's `getBuffer` is callback-based with no error channel, asynchronous failures (like font/VFS resolution problems) would cause the export to hang indefinitely. The timeout ensures users see a real error instead of silent failure.

- **Callback Settlement Tracking**: Added a `settled` flag to prevent race conditions between the timeout, successful callback, and error handler, ensuring only one resolution path executes.

- **Tauri Permissions**: Added `core:window:allow-set-title` permission to the default capabilities.

## Implementation Details

The font mapping pins the four Roboto typeface variants (normal, bold, italics, bolditalics) to the TTF files shipped in vfs_fonts, matching pdfmake's expected font structure. The timeout and settlement tracking work together to handle edge cases where the PDFKit pipeline fails asynchronously without invoking the callback.

https://claude.ai/code/session_013V1R1GHsF2tkhvavJZxAfj