### PR TITLE
Add Mermaid code rendering support

### DIFF
--- a/src/features/editor/codeBlockSyntax.ts
+++ b/src/features/editor/codeBlockSyntax.ts
@@ -1,9 +1,11 @@
 import CodeBlock from "@tiptap/extension-code-block";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import { Plugin } from "@tiptap/pm/state";
 import { Decoration, DecorationSet } from "@tiptap/pm/view";
 
 export const SUPPORTED_CODE_BLOCK_LANGUAGES = [
   "plaintext",
+  "mermaid",
   "javascript",
   "typescript",
   "json",
@@ -21,6 +23,8 @@ const LANGUAGE_ALIASES: Record<string, SupportedCodeBlockLanguage> = {
   text: "plaintext",
   plain: "plaintext",
   plaintext: "plaintext",
+  mermaid: "mermaid",
+  mmd: "mermaid",
   js: "javascript",
   javascript: "javascript",
   ts: "typescript",
@@ -256,6 +260,126 @@ function highlightCode(language: string | null | undefined, text: string, offset
   return decorations;
 }
 
+interface MermaidApi {
+  initialize: (config: Record<string, unknown>) => void;
+  render: (id: string, definition: string) => Promise<{ svg: string }>;
+}
+
+declare global {
+  interface Window {
+    mermaid?: MermaidApi;
+    __mdeditMermaidLoader?: Promise<MermaidApi>;
+  }
+}
+
+const MERMAID_CDN_URL = "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js";
+let mermaidRenderId = 0;
+
+function loadMermaid(): Promise<MermaidApi> {
+  if (window.mermaid) {
+    return Promise.resolve(window.mermaid);
+  }
+
+  if (window.__mdeditMermaidLoader) {
+    return window.__mdeditMermaidLoader;
+  }
+
+  window.__mdeditMermaidLoader = new Promise((resolve, reject) => {
+    const script = document.createElement("script");
+    script.src = MERMAID_CDN_URL;
+    script.async = true;
+    script.onload = () => {
+      if (!window.mermaid) {
+        reject(new Error("Mermaid renderer did not become available."));
+        return;
+      }
+
+      window.mermaid.initialize({
+        startOnLoad: false,
+        securityLevel: "strict",
+        theme: "default",
+      });
+      resolve(window.mermaid);
+    };
+    script.onerror = () => reject(new Error("Unable to load Mermaid renderer."));
+    document.head.append(script);
+  });
+
+  return window.__mdeditMermaidLoader;
+}
+
+function createMermaidCodeBlockView() {
+  return ({ node }: { node: ProseMirrorNode }) => {
+    const wrapper = document.createElement("div");
+    wrapper.className = "mermaid-code-block";
+
+    const pre = document.createElement("pre");
+    const code = document.createElement("code");
+    code.spellcheck = false;
+    pre.append(code);
+
+    const preview = document.createElement("div");
+    preview.className = "mermaid-preview";
+    preview.contentEditable = "false";
+
+    wrapper.append(pre, preview);
+
+    let lastRenderedSource: string | null = null;
+    let renderVersion = 0;
+
+    const renderPreview = (language: string | null | undefined, source: string) => {
+      const isMermaid = normalizeCodeBlockLanguage(language) === "mermaid";
+      wrapper.classList.toggle("is-mermaid", isMermaid);
+
+      if (!isMermaid) {
+        preview.replaceChildren();
+        lastRenderedSource = null;
+        return;
+      }
+
+      if (lastRenderedSource === source) return;
+      lastRenderedSource = source;
+
+      const currentRenderVersion = ++renderVersion;
+      preview.setAttribute("aria-busy", "true");
+      preview.textContent = source.trim() ? "Rendering Mermaid diagram…" : "Enter Mermaid code to render a diagram.";
+
+      if (!source.trim()) {
+        preview.removeAttribute("aria-busy");
+        return;
+      }
+
+      void loadMermaid()
+        .then((mermaid) =>
+          mermaid.render(`mdedit-mermaid-${++mermaidRenderId}`, source)
+        )
+        .then(({ svg }) => {
+          if (currentRenderVersion !== renderVersion) return;
+          preview.innerHTML = svg;
+          preview.removeAttribute("aria-busy");
+        })
+        .catch((error) => {
+          if (currentRenderVersion !== renderVersion) return;
+          preview.textContent =
+            error instanceof Error ? error.message : "Unable to render Mermaid diagram.";
+          preview.removeAttribute("aria-busy");
+        });
+    };
+
+    renderPreview(node.attrs.language, node.textContent);
+
+    return {
+      dom: wrapper,
+      contentDOM: code,
+      update: (updatedNode: ProseMirrorNode) => {
+        if (updatedNode.type !== node.type) return false;
+        renderPreview(updatedNode.attrs.language, updatedNode.textContent);
+        return true;
+      },
+    };
+  };
+}
+
 export function normalizeCodeBlockLanguage(language: string | null | undefined): SupportedCodeBlockLanguage {
   if (!language) return "plaintext";
   const normalized = LANGUAGE_ALIASES[language.trim().toLowerCase()];
@@ -288,5 +412,9 @@ export const CodeBlockWithSyntax = CodeBlock.extend({
         },
       }),
     ];
+  },
+
+  addNodeView() {
+    return createMermaidCodeBlockView();
   },
 });

--- a/src/services/markdownService.ts
+++ b/src/services/markdownService.ts
@@ -90,6 +90,18 @@ pre code {
   border-radius: 0;
   color: inherit;
 }
+.mermaid {
+  margin: 1rem 0;
+  padding: 1rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  text-align: center;
+}
+.mermaid svg {
+  max-width: 100%;
+  height: auto;
+}
 table {
   width: 100%;
   border-collapse: collapse;
@@ -109,6 +121,28 @@ th {
 input[type="checkbox"] {
   vertical-align: middle;
 }
+`;
+
+const MERMAID_EXPORT_SCRIPT = `
+<script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    document.querySelectorAll("pre > code.language-mermaid").forEach(function (code) {
+      var container = document.createElement("div");
+      container.className = "mermaid";
+      container.textContent = code.textContent || "";
+      code.parentElement.replaceWith(container);
+    });
+
+    if (window.mermaid) {
+      window.mermaid.initialize({
+        startOnLoad: true,
+        securityLevel: "strict",
+        theme: "default"
+      });
+    }
+  });
+</script>
 `;
 
 const EXPORT_PRINT_CSS = `
@@ -184,6 +218,7 @@ export function buildHtmlDocument({
     "</head>",
     "<body>",
     `  <article>${bodyHtml}</article>`,
+    MERMAID_EXPORT_SCRIPT,
     "</body>",
     "</html>",
   ].join("\n");

--- a/src/styles.css
+++ b/src/styles.css
@@ -437,6 +437,45 @@ body {
   color: #7a2f8f;
 }
 
+.ProseMirror .mermaid-code-block {
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  overflow: hidden;
+  background: #fafafa;
+}
+
+.ProseMirror .mermaid-code-block pre {
+  border: none;
+  border-radius: 0;
+  margin: 0;
+}
+
+.ProseMirror .mermaid-code-block.is-mermaid pre {
+  border-bottom: 1px solid var(--color-border);
+}
+
+.ProseMirror .mermaid-preview {
+  display: none;
+}
+
+.ProseMirror .mermaid-code-block.is-mermaid .mermaid-preview {
+  display: block;
+  min-height: 72px;
+  padding: 16px;
+  overflow-x: auto;
+  background: #fff;
+  color: var(--color-text-muted);
+  font-family: var(--font-ui);
+  font-size: 13px;
+  line-height: 1.4;
+  text-align: center;
+}
+
+.ProseMirror .mermaid-preview svg {
+  max-width: 100%;
+  height: auto;
+}
+
 .ProseMirror hr {
   border: none;
   border-top: 2px solid var(--color-border);


### PR DESCRIPTION
### Motivation

- Enable authors to write and preview Mermaid diagrams inline in code blocks and include rendered diagrams in HTML exports.

### Description

- Add `mermaid` (and alias `mmd`) to `SUPPORTED_CODE_BLOCK_LANGUAGES` and expose it in the code-language control (`src/features/editor/codeBlockSyntax.ts`).
- Implement an on-demand Mermaid loader that pulls the renderer from the jsDelivr CDN and a Tiptap node view that keeps the `code` editable while rendering a preview beneath it with loading/error states (`src/features/editor/codeBlockSyntax.ts`).
- Include export-time conversion and runtime initialization for Mermaid diagrams so exported HTML replaces `pre > code.language-mermaid` with rendered diagrams (`src/services/markdownService.ts`).
- Add editor and export styles for Mermaid containers and the preview area (`src/styles.css` and `src/services/markdownService.ts`).

### Testing

- Ran the production build with `npm run build`, which completed successfully.
- Attempted `npm install mermaid` but the registry returned a `403`, so the implementation uses runtime CDN loading from `https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js` instead of adding a package dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4621499d948322a3871527c64a27a1)